### PR TITLE
React 프론트엔드 연동: CORS/JWT/Whitelist 구성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,9 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     runtimeOnly 'com.mysql:mysql-connector-j'
+
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.13'
+
 }
 
 tasks.named('test') {

--- a/frontend/gradu-web/src/components/AddCourseModal.css
+++ b/frontend/gradu-web/src/components/AddCourseModal.css
@@ -59,3 +59,22 @@
 .addcourse-row input[type="number"] {
   -moz-appearance: textfield;
 }
+
+/* 간단 토글 */
+.acm-toggle { position: relative; display: inline-block; width: 44px; height: 24px; }
+.acm-toggle input { opacity: 0; width: 0; height: 0; }
+.acm-toggle span {
+  position: absolute; inset: 0; background: #e5e7eb; border-radius: 999px; transition: .2s;
+}
+.acm-toggle span::before {
+  content: ""; position: absolute; width: 18px; height: 18px; left: 3px; top: 3px;
+  background: #fff; border-radius: 50%; transition: .2s;
+}
+.acm-toggle input:checked + span { background: #2563eb; }
+.acm-toggle input:checked + span::before { transform: translateX(20px); }
+
+/* 버튼(예시, 기존 파일에 있으면 생략 가능) */
+.addcourse-btn { border: none; }
+.addcourse-btn--ghost { background: #fff; border: 1px solid #d1d5db; }
+.addcourse-btn--primary { background: #2563eb; color: #fff; }
+.addcourse-select { appearance: auto; }

--- a/frontend/gradu-web/src/components/AddCourseModal.tsx
+++ b/frontend/gradu-web/src/components/AddCourseModal.tsx
@@ -1,5 +1,5 @@
 // src/components/AddCourseModal.tsx
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useMutation } from "@tanstack/react-query";
 import { axiosInstance } from "../lib/axios";
 import Modal from "./Modal";
@@ -26,38 +26,69 @@ const KOR_LABELS = {
 
 const ORDER = Object.keys(KOR_LABELS) as Array<keyof typeof KOR_LABELS>;
 
-/** 화면 입력 상태: 숫자 필드도 문자열로 관리 */
+/** 화면 입력 상태: 숫자도 문자열로 관리 */
 type CourseInput = {
   name: string;
-  credit: string;          // ← string
-  designedCredit: string;  // ← string
+  credit: string;          // "3" 처럼 문자열
+  designedCredit: string;  // 전공(MAJOR)일 때만 사용
   category: keyof typeof KOR_LABELS;
-  grade: string;
+  grade: string;           // "A+", "P" 등
+  isEnglish: boolean;      // ✅ 영어강의 여부
 };
 
-/** 서버 전송 payload: 숫자로 변환 */
+/** 서버 전송 payload */
 type CourseRequest = {
   name: string;
   credit: number;
-  designedCredit: number;
+  designedCredit: number | null;  // 전공 아니면 null
   category: keyof typeof KOR_LABELS;
-  grade: string;
+  grade: string | null;
+  isEnglish: boolean;             // ✅ 서버로 전송
 };
 
 export default function AddCourseModal({ open, sid, onClose, onSaved }: Props) {
   const [form, setForm] = useState<CourseInput>({
     name: "",
-    credit: "",           // ← 빈 문자열 (0 안보임)
-    designedCredit: "",   // ← 빈 문자열
+    credit: "",
+    designedCredit: "",
     category: "FAITH_WORLDVIEW",
     grade: "",
+    isEnglish: false,
   });
   const [errMsg, setErrMsg] = useState("");
 
+  const isMajor = form.category === "MAJOR";
+
+  /** 모달 열릴 때마다 폼 초기화 */
+  useEffect(() => {
+    if (open) {
+      setErrMsg("");
+      setForm({
+        name: "",
+        credit: "",
+        designedCredit: "",
+        category: "FAITH_WORLDVIEW",
+        grade: "",
+        isEnglish: false,
+      });
+    }
+  }, [open]);
+
   /** 입력 변경 */
-  const onChange = <K extends keyof CourseInput>(k: K, v: string) => {
+  const onChange = <K extends keyof CourseInput>(k: K, v: CourseInput[K]) => {
+    // 숫자 필드 정제
     if (k === "credit" || k === "designedCredit") {
-      v = v.replace(/\D/g, ""); // 숫자 이외 제거
+      if (typeof v === "string") v = (v as string).replace(/\D/g, "") as any;
+    }
+    // 카테고리 바꾸면 전공이 아닌 경우 설계학점 클리어
+    if (k === "category") {
+      const nextCat = v as CourseInput["category"];
+      setForm((f) => ({
+        ...f,
+        category: nextCat,
+        designedCredit: nextCat === "MAJOR" ? f.designedCredit : "",
+      }));
+      return;
     }
     setForm((f) => ({ ...f, [k]: v }));
   };
@@ -72,13 +103,6 @@ export default function AddCourseModal({ open, sid, onClose, onSaved }: Props) {
     },
     onSuccess: () => {
       setErrMsg("");
-      setForm({
-        name: "",
-        credit: "",
-        designedCredit: "",
-        category: "FAITH_WORLDVIEW",
-        grade: "",
-      });
       onSaved();
       onClose();
     },
@@ -89,6 +113,35 @@ export default function AddCourseModal({ open, sid, onClose, onSaved }: Props) {
       console.error("[addCourse] error", e);
     },
   });
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!form.name.trim()) {
+      setErrMsg("과목명을 입력하세요.");
+      return;
+    }
+    if (form.credit === "") {
+      setErrMsg("학점을 입력하세요.");
+      return;
+    }
+    setErrMsg("");
+
+    // 문자열 → 숫자 변환
+    const creditNum = Number(form.credit);
+    const designedNum =
+      isMajor && form.designedCredit !== "" ? Number(form.designedCredit) : null;
+
+    const payload: CourseRequest = {
+      name: form.name.trim(),
+      credit: Number.isNaN(creditNum) ? 0 : creditNum,
+      designedCredit: designedNum,
+      category: form.category,
+      grade: form.grade.trim() === "" ? null : form.grade.trim(),
+      isEnglish: !!form.isEnglish, // ✅ 영어강의 여부
+    };
+
+    await addCourse.mutateAsync(payload);
+  }
 
   // ---- inline style tokens ----
   const s = {
@@ -104,7 +157,7 @@ export default function AddCourseModal({ open, sid, onClose, onSaved }: Props) {
       color: "#111",
       boxSizing: "border-box",
     } as const,
-    row: { gap: 16 } as const,
+    row: { display: "grid", gridTemplateColumns: "1fr 1fr", gap: 16 } as const,
     error: {
       borderRadius: 8,
       background: "#fef2f2",
@@ -119,27 +172,9 @@ export default function AddCourseModal({ open, sid, onClose, onSaved }: Props) {
       cursor: "pointer",
       fontSize: 14,
     } as const,
+    hint: { color: "#6b7280", fontWeight: 400 } as const,
+    toggleWrap: { display: "flex", alignItems: "center", gap: 10 } as const,
   };
-
-  async function onSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    if (!form.name.trim()) {
-      setErrMsg("과목명을 입력하세요.");
-      return;
-    }
-    setErrMsg("");
-
-    // 문자열 → 숫자 변환 (빈 문자열이면 0)
-    const payload: CourseRequest = {
-      name: form.name.trim(),
-      credit: form.credit === "" ? 0 : Number(form.credit),
-      designedCredit: form.designedCredit === "" ? 0 : Number(form.designedCredit),
-      category: form.category,
-      grade: form.grade.trim(),
-    };
-
-    await addCourse.mutateAsync(payload);
-  }
 
   return (
     <Modal
@@ -162,7 +197,7 @@ export default function AddCourseModal({ open, sid, onClose, onSaved }: Props) {
             type="submit"
             className="addcourse-btn addcourse-btn--primary"
             style={s.footerBtnBase}
-            disabled={addCourse.isPending || !form.name}
+            disabled={addCourse.isPending || !form.name || form.credit === ""}
           >
             {addCourse.isPending ? "저장 중..." : "저장"}
           </button>
@@ -183,12 +218,12 @@ export default function AddCourseModal({ open, sid, onClose, onSaved }: Props) {
           />
         </div>
 
-        {/* 학점/설계학점 */}
+        {/* 학점 / (전공일 때만) 설계학점 */}
         <div className="addcourse-row" style={s.row}>
           <div>
             <label style={s.label}>학점</label>
             <input
-              type="text"                 // ← text로 두고
+              type="text"                 // 문자열로 관리
               inputMode="numeric"         // 모바일 숫자 키패드
               pattern="[0-9]*"            // 숫자만
               style={s.input}
@@ -197,18 +232,38 @@ export default function AddCourseModal({ open, sid, onClose, onSaved }: Props) {
               placeholder="0"
             />
           </div>
-          <div>
-            <label style={s.label}>설계학점</label>
-            <input
-              type="text"
-              inputMode="numeric"
-              pattern="[0-9]*"
-              style={s.input}
-              value={form.designedCredit}
-              onChange={(e) => onChange("designedCredit", e.target.value)}
-              placeholder="0"
-            />
-          </div>
+
+          {isMajor ? (
+            <div>
+              <label style={s.label}>
+                설계학점 <span style={s.hint}>(전공만 해당)</span>
+              </label>
+              <input
+                type="text"
+                inputMode="numeric"
+                pattern="[0-9]*"
+                style={s.input}
+                value={form.designedCredit}
+                onChange={(e) => onChange("designedCredit", e.target.value)}
+                placeholder="0"
+              />
+            </div>
+          ) : (
+            <div>
+              <label style={s.label}>
+                설계학점 <span style={s.hint}>(전공만 입력 가능)</span>
+              </label>
+              <input
+                type="text"
+                inputMode="numeric"
+                pattern="[0-9]*"
+                style={{ ...s.input, background: "#f3f4f6" }}
+                value=""
+                disabled
+                placeholder="-"
+              />
+            </div>
+          )}
         </div>
 
         {/* 카테고리 */}
@@ -218,7 +273,7 @@ export default function AddCourseModal({ open, sid, onClose, onSaved }: Props) {
             className="addcourse-select"
             style={s.input}
             value={form.category}
-            onChange={(e) => onChange("category", e.target.value)}
+            onChange={(e) => onChange("category", e.target.value as CourseInput["category"])}
           >
             {ORDER.map((key) => (
               <option key={key} value={key}>
@@ -231,14 +286,30 @@ export default function AddCourseModal({ open, sid, onClose, onSaved }: Props) {
         {/* 성적 */}
         <div style={s.field}>
           <label style={s.label}>
-            성적 <span style={{ color: "#9ca3af", fontWeight: 400 }}>(예: A, B+, P)</span>
+            성적 <span style={s.hint}>(예: A+, A0, B+, P 등)</span>
           </label>
           <input
             style={s.input}
-            placeholder="예: A, B+, P"
+            placeholder="예: A+, B0, P"
             value={form.grade}
             onChange={(e) => onChange("grade", e.target.value)}
           />
+        </div>
+
+        {/* 영어강의 여부 */}
+        <div style={s.field}>
+          <label style={s.label}>영어강의 여부</label>
+          <div style={s.toggleWrap}>
+            <label className="acm-toggle">
+              <input
+                type="checkbox"
+                checked={form.isEnglish}
+                onChange={(e) => onChange("isEnglish", e.target.checked)}
+              />
+              <span />
+            </label>
+            <span>{form.isEnglish ? "영어강의" : "일반강의"}</span>
+          </div>
         </div>
       </form>
     </Modal>

--- a/frontend/gradu-web/src/components/EditCourseModal.css
+++ b/frontend/gradu-web/src/components/EditCourseModal.css
@@ -1,0 +1,41 @@
+.ecm-form { display: grid; gap: 12px; font-size: 14px; }
+.ecm-label { display: grid; gap: 6px; }
+.ecm-label-title { display:inline-block; margin-right:8px; font-weight:600; color:#111827; }
+.ecm-input {
+  width: 100%;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  padding: 8px 12px;
+  background: #fff;
+  color: #111;
+  box-sizing: border-box;
+}
+.ecm-grid2 { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+.ecm-field { display: flex; align-items: center; gap: 10px; }
+
+.ecm-error {
+  border-radius: 8px;
+  background: #fef2f2;
+  color: #b91c1c;
+  border: 1px solid #fecaca;
+  padding: 8px 12px;
+}
+
+/* 버튼 */
+.ecm-btn { border-radius: 8px; padding: 8px 16px; cursor: pointer; font-size: 14px; border: none; }
+.ecm-btn--ghost { background: #fff; border: 1px solid #d1d5db; }
+.ecm-btn--primary { background: #2563eb; color: #fff; }
+
+/* 토글 */
+.ecm-toggle { position: relative; display: inline-block; width: 44px; height: 24px; }
+.ecm-toggle input { opacity: 0; width: 0; height: 0; }
+.ecm-toggle span {
+  position: absolute; inset: 0; background: #e5e7eb; border-radius: 999px; transition: .2s;
+}
+.ecm-toggle span::before {
+  content: ""; position: absolute; width: 18px; height: 18px; left: 3px; top: 3px;
+  background: #fff; border-radius: 50%; transition: .2s;
+}
+.ecm-toggle input:checked + span { background: #2563eb; }
+.ecm-toggle input:checked + span::before { transform: translateX(20px); }
+.ecm-toggle-text { color:#374151; }

--- a/frontend/gradu-web/src/components/EditCourseModal.tsx
+++ b/frontend/gradu-web/src/components/EditCourseModal.tsx
@@ -1,0 +1,256 @@
+// src/components/EditCourseModal.tsx
+import { useEffect, useMemo, useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { axiosInstance } from "../lib/axios";
+import Modal from "./Modal";
+// ✅ 별도 CSS 제거, 페이지 CSS 모듈만 사용
+import s from "../pages/CurriculumDetail.module.css";
+// ✅ 타입 전용 import (verbatimModuleSyntax 호환)
+import type { CourseDto } from "../pages/CurriculumDetailPage";
+
+const KOR_LABELS: Record<string, string> = {
+  FAITH_WORLDVIEW: "신앙및세계관",
+  PERSONALITY_LEADERSHIP: "인성및리더십",
+  PRACTICAL_ENGLISH: "실무영어",
+  GENERAL_EDU: "전문교양",
+  BSM: "BSM",
+  ICT_INTRO: "ICT융합기초",
+  FREE_ELECTIVE_BASIC: "자유선택(교양)",
+  FREE_ELECTIVE_MJR: "자유선택(교양또는비교양)",
+  MAJOR: "전공",
+};
+const CATEGORY_ORDER = Object.keys(KOR_LABELS);
+
+type Props = {
+  open: boolean;
+  course: CourseDto | null;
+  sid: string;
+  onClose: () => void;
+  onSaved: () => void;
+};
+
+type FormState = {
+  name: string;
+  credit: string;          // 문자열로 관리
+  designedCredit: string;  // 문자열
+  grade: string;
+  category: string;
+  isEnglish: boolean;
+};
+
+export default function EditCourseModal({ open, course, sid, onClose, onSaved }: Props) {
+  const [form, setForm] = useState<FormState>({
+    name: "",
+    credit: "",
+    designedCredit: "",
+    grade: "",
+    category: "MAJOR",
+    isEnglish: false,
+  });
+  const [errMsg, setErrMsg] = useState("");
+
+  const isMajor = useMemo(() => form.category === "MAJOR", [form.category]);
+
+  useEffect(() => {
+    if (open && course) {
+      setErrMsg("");
+      setForm({
+        name: course.name ?? "",
+        credit: String(course.credit ?? ""),
+        designedCredit:
+          course.category === "MAJOR" && course.designedCredit != null
+            ? String(course.designedCredit)
+            : "",
+        grade: course.grade ?? "",
+        category: course.category ?? "MAJOR",
+        isEnglish: !!course.isEnglish,
+      });
+    }
+  }, [open, course]);
+
+  const onChange = <K extends keyof FormState>(k: K, v: FormState[K]) => {
+    if (k === "credit" || k === "designedCredit") {
+      if (typeof v === "string") v = (v as string).replace(/\D/g, "") as any;
+    }
+    if (k === "category") {
+      const nextCat = v as string;
+      setForm((f) => ({
+        ...f,
+        category: nextCat,
+        designedCredit: nextCat === "MAJOR" ? f.designedCredit : "",
+      }));
+      return;
+    }
+    setForm((f) => ({ ...f, [k]: v }));
+  };
+
+  const patchMutation = useMutation({
+    mutationFn: async () => {
+      if (!course) return;
+
+      const creditNum =
+        form.credit.trim() === "" ? null : Number(form.credit.trim());
+      const designedNumRaw =
+        form.designedCredit.trim() === "" ? null : Number(form.designedCredit.trim());
+      const designedNum =
+        isMajor ? (Number.isNaN(designedNumRaw as number) ? null : designedNumRaw) : null;
+
+      const body: Partial<{
+        name: string;
+        credit: number | null;
+        designedCredit: number | null;
+        grade: string | null;
+        category: string | null;
+        isEnglish: boolean;
+      }> = {
+        name: form.name.trim() === "" ? undefined : form.name.trim(),
+        credit: Number.isNaN(creditNum as number) ? null : creditNum,
+        designedCredit: designedNum,
+        grade: form.grade.trim() === "" ? null : form.grade.trim(),
+        category: form.category,
+        isEnglish: !!form.isEnglish,
+      };
+
+      const url = `/api/v1/students/${encodeURIComponent(sid)}/courses/${course.id}`;
+      await axiosInstance.patch(url, body);
+    },
+    onSuccess: () => onSaved(),
+    onError: (e: any) => {
+      const status = e?.response?.status;
+      const text = e?.response?.data?.message || e?.message || "요청 실패";
+      setErrMsg(`저장 실패 (${status ?? "-"}) : ${text}`);
+      console.error("[EditCourse] error", e);
+    },
+  });
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!course) return;
+    if (!form.name.trim()) {
+      setErrMsg("과목명을 입력하세요.");
+      return;
+    }
+    if (form.credit.trim() === "") {
+      setErrMsg("학점을 입력하세요.");
+      return;
+    }
+    setErrMsg("");
+    await patchMutation.mutateAsync();
+  };
+
+  return (
+    <Modal
+      open={open}
+      onClose={() => !patchMutation.isPending && onClose()}
+      title="과목 수정"
+      /* 푸터 버튼 */
+      footer={
+        <>
+          <button
+            type="button"
+            className={s.btnGhost}
+            disabled={patchMutation.isPending}
+            onClick={onClose}
+          >
+            취소
+          </button>
+          <button
+            form="edit-course-form"
+            type="submit"
+            className={s.btnPrimary}
+            disabled={patchMutation.isPending}
+          >
+            {patchMutation.isPending ? "저장 중…" : "저장"}
+          </button>
+        </>
+      }
+    >
+      {/* === 모달 본문 === */}
+      <form id="edit-course-form" onSubmit={onSubmit} className={s.form}>
+        {errMsg && <div className={s.error}>{errMsg}</div>}
+
+        <div className={s.label}>
+          과목명
+          <input
+            className={s.input}
+            value={form.name}
+            onChange={(e) => onChange("name", e.target.value)}
+            placeholder="예: 자료구조"
+          />
+        </div>
+
+        <div className={s.grid2}>
+            <label className={s.label}>
+              학점
+              <input
+                className={s.input}
+                type="text"
+                inputMode="numeric"
+                pattern="[0-9]*"
+                value={form.credit}
+                onChange={(e) => onChange("credit", e.target.value)}
+                placeholder="예: 3"
+              />
+            </label>
+
+            <label className={s.label}>
+              카테고리
+              <select
+                className={s.input}
+                value={form.category}
+                onChange={(e) => onChange("category", e.target.value)}
+              >
+                {CATEGORY_ORDER.map((key) => (
+                  <option key={key} value={key}>
+                    {KOR_LABELS[key]}
+                  </option>
+                ))}
+              </select>
+            </label>
+        </div>
+
+        {isMajor && (
+          <label className={s.label}>
+            설계학점
+            <input
+              className={s.input}
+              type="text"
+              inputMode="numeric"
+              pattern="[0-9]*"
+              value={form.designedCredit}
+              onChange={(e) => onChange("designedCredit", e.target.value)}
+              placeholder="예: 2"
+            />
+          </label>
+        )}
+
+        <label className={s.label}>
+          성적
+          <input
+            className={s.input}
+            value={form.grade}
+            onChange={(e) => onChange("grade", e.target.value)}
+            placeholder="예: A+"
+          />
+        </label>
+
+        {/* 영어강의 여부(기본 체크박스) */}
+        <div className={s.label}>
+          영어강의 여부
+          <div>
+            <label style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
+              <input
+                type="checkbox"
+                checked={form.isEnglish}
+                onChange={(e) => onChange("isEnglish", e.target.checked)}
+              />
+              <span>{form.isEnglish ? "영어강의" : "일반강의"}</span>
+            </label>
+          </div>
+        </div>
+
+        {/* 하단 버튼 영역은 Modal footer 사용 */}
+      </form>
+    </Modal>
+  );
+}

--- a/frontend/gradu-web/src/main.tsx
+++ b/frontend/gradu-web/src/main.tsx
@@ -1,34 +1,51 @@
-// src/main.tsx (또는 router 파일)
+// src/main.tsx
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { createBrowserRouter, RouterProvider } from "react-router-dom";
+import {
+  createBrowserRouter,
+  RouterProvider,
+  Navigate,
+  Outlet,
+} from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 import AppShell from "./components/AppShell";
 import CurriculumPage from "./pages/CurriculumPage";
+import CurriculumDetailPage from "./pages/CurriculumDetailPage"; // ← 상세 페이지
 import LoginPage from "./pages/LoginPage";
 import RegisterPage from "./pages/RegisterPage";
 import { PrivateRoute } from "./routes/PrivateRoute";
-import './index.css';          // tailwind 포함
-import './styles/reset.css';   // ★ 마지막에
+
+import "./index.css";
+import "./styles/reset.css"; // (원하는 대로) 마지막에
 
 const qc = new QueryClient();
 
+const PrivateLayout = () => (
+  <PrivateRoute>
+    <AppShell>
+      <Outlet />
+    </AppShell>
+  </PrivateRoute>
+);
+
 const router = createBrowserRouter([
+  // 공개 라우트
   { path: "/login", element: <LoginPage /> },
   { path: "/register", element: <RegisterPage /> },
 
-  // 기본은 커리큘럼 + AppShell
+  // 보호된 라우트(레이아웃 + 중첩)
   {
-    path: "/",
-    element: (
-      <PrivateRoute>
-        <AppShell>
-          <CurriculumPage />
-        </AppShell>
-      </PrivateRoute>
-    ),
+    element: <PrivateLayout />,
+    children: [
+      { path: "/", element: <Navigate to="/curriculum" replace /> }, // 기본 리다이렉트
+      { path: "/curriculum", element: <CurriculumPage /> },
+      { path: "/curriculum/:category", element: <CurriculumDetailPage /> }, // 상세
+    ],
   },
+
+  // 기타 → 홈으로
+  { path: "*", element: <Navigate to="/" replace /> },
 ]);
 
 ReactDOM.createRoot(document.getElementById("root")!).render(

--- a/frontend/gradu-web/src/pages/CurriculumDetail.module.css
+++ b/frontend/gradu-web/src/pages/CurriculumDetail.module.css
@@ -1,0 +1,183 @@
+.page {
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: 24px;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 24px;
+}
+
+.titleSub {
+  font-size: 12px;
+  color: #6b7280;
+  margin-bottom: 4px;
+}
+
+.title {
+  font-size: 24px;
+  font-weight: 600;
+  margin: 0;
+}
+
+.backBtn {
+  border-radius: 8px;
+  border: 1px solid #d1d5db;
+  background: #fff;
+  padding: 6px 12px;
+  font-size: 14px;
+  cursor: pointer;
+}
+.backBtn:hover { background: #f9fafb; }
+
+.card {
+  overflow-x: auto;
+  border-radius: 16px;
+  border: 1px solid #e5e7eb;
+  background: #fff;
+}
+
+.table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  font-size: 15px;
+}
+
+.th {
+  border: 1px solid #e5e7eb;
+  padding: 12px 16px;
+  text-align: center;
+  background: #f9fafb;
+  color: #374151;
+  font-weight: 600;
+}
+
+.td {
+  border: 1px solid #e5e7eb;
+  padding: 12px 16px;
+  text-align: center;
+}
+
+.tdActions {
+  border: 1px solid #e5e7eb;
+  padding: 12px 16px;
+  text-align: center;      /* 가로 가운데 */
+  vertical-align: middle;  /* 세로 가운데 */
+}
+
+.btnGroup {
+  display: inline-flex;    /* 내용만큼 크기 */
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}
+
+.rowEven {
+  background: rgba(249, 250, 251, 0.4);
+}
+
+.loading, .empty {
+  padding: 32px;
+  text-align: center;
+  color: #4b5563;
+}
+
+.error {
+  padding: 32px;
+  text-align: center;
+  color: #dc2626;
+}
+.errorSub {
+  margin-top: 8px;
+  font-size: 13px;
+  color: #6b7280;
+}
+
+.centerNotice {
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: 24px;
+  text-align: center;
+}
+
+/* 버튼 */
+.btnGhost {
+  background: transparent;
+  border: 1px solid #d0d5dd;
+  padding: 6px 10px;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.btnDanger {
+  background: #ef4444;
+  border: none;
+  color: white;
+  padding: 6px 10px;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.btnPrimary {
+  background: #2563eb;
+  color: white;
+  border: none;
+  padding: 8px 14px;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+/* 모달 */
+.modalBackdrop {
+  position: fixed; inset: 0;
+  background: rgba(0,0,0,0.35);
+  display: flex; align-items: center; justify-content: center;
+  z-index: 50;
+}
+
+.modal {
+  width: 420px; max-width: 92vw;
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 10px 24px rgba(0,0,0,0.14);
+  padding: 16px;
+}
+
+.modalHeader {
+  display: flex; align-items: center; justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.modalTitle {
+  font-size: 18px; font-weight: 700;
+}
+
+.modalClose {
+  background: transparent; border: none; font-size: 22px; cursor: pointer;
+}
+
+.form {
+  display: grid; gap: 12px;
+}
+
+.grid2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+.label {
+  display: grid; gap: 6px; font-size: 14px;
+}
+
+.input {
+  border: 1px solid #d0d5dd; border-radius: 8px; padding: 8px 10px;
+}
+
+.modalActions {
+  display: flex; justify-content: flex-end; gap: 10px; margin-top: 8px;
+}

--- a/frontend/gradu-web/src/pages/CurriculumDetailPage.tsx
+++ b/frontend/gradu-web/src/pages/CurriculumDetailPage.tsx
@@ -1,0 +1,163 @@
+// src/pages/CurriculumDetailPage.tsx
+import { useMemo, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { axiosInstance, getStudentId } from "../lib/axios";
+import EditCourseModal from "../components/EditCourseModal";
+import s from "./CurriculumDetail.module.css";
+
+export type CourseDto = {
+  id: number;
+  name: string;
+  credit: number;
+  designedCredit: number | null;
+  category: string;
+  grade: string | null;
+  isEnglish?: boolean;
+};
+
+export const KOR_LABELS: Record<string, string> = {
+  FAITH_WORLDVIEW: "신앙및세계관",
+  PERSONALITY_LEADERSHIP: "인성및리더십",
+  PRACTICAL_ENGLISH: "실무영어",
+  GENERAL_EDU: "전문교양",
+  BSM: "BSM",
+  ICT_INTRO: "ICT융합기초",
+  FREE_ELECTIVE_BASIC: "자유선택(교양)",
+  FREE_ELECTIVE_MJR: "자유선택(교양또는비교양)",
+  MAJOR: "전공",
+};
+export const CATEGORY_ORDER = Object.keys(KOR_LABELS);
+const ALLOWED = new Set(CATEGORY_ORDER);
+
+export default function CurriculumDetailPage() {
+  const { category = "" } = useParams();
+  const sid = getStudentId() || "";
+  const nav = useNavigate();
+  const qc = useQueryClient();
+
+  const categoryEnum = useMemo(
+    () => category.toUpperCase().replace(/-/g, "_"),
+    [category]
+  );
+  const isValid = ALLOWED.has(categoryEnum);
+  const label = isValid ? KOR_LABELS[categoryEnum] : categoryEnum;
+  const isMajor = categoryEnum === "MAJOR";
+
+  const { data = [], isLoading, isError, error } = useQuery<CourseDto[]>({
+    queryKey: ["courses-by-category", sid, categoryEnum],
+    enabled: !!sid && isValid,
+    queryFn: async () => {
+      const url = `/api/v1/students/${encodeURIComponent(
+        sid
+      )}/courses/categories/${encodeURIComponent(categoryEnum)}`;
+      const { data } = await axiosInstance.get<CourseDto[]>(url);
+      return data ?? [];
+    },
+  });
+
+  // 삭제
+  const deleteMutation = useMutation({
+    mutationFn: async (courseId: number) => {
+      const url = `/api/v1/students/${encodeURIComponent(sid)}/courses/${courseId}`;
+      await axiosInstance.delete(url);
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["courses-by-category", sid, categoryEnum] });
+    },
+  });
+
+  // 수정 모달 상태
+  const [editing, setEditing] = useState<CourseDto | null>(null);
+  const closeEdit = () => setEditing(null);
+  const handleEdited = () => {
+    qc.invalidateQueries({ queryKey: ["courses-by-category", sid, categoryEnum] });
+    closeEdit();
+  };
+
+  if (!sid) return <div className={s.centerNotice}>로그인 정보를 찾을 수 없습니다.</div>;
+  if (!isValid) {
+    return (
+      <div className={s.centerNotice}>
+        잘못된 카테고리입니다: <b>{category}</b>
+      </div>
+    );
+  }
+
+  return (
+    <div className={s.page}>
+      {/* 상단 */}
+      <div className={s.header}>
+        <div>
+          <div className={s.titleSub}>카테고리 상세</div>
+          <h2 className={s.title}>{label}</h2>
+        </div>
+        <button onClick={() => nav(-1)} className={s.backBtn}>
+          뒤로
+        </button>
+      </div>
+
+      {/* 본문 카드 */}
+      <div className={s.card}>
+        {isLoading ? (
+          <div className={s.loading}>불러오는 중…</div>
+        ) : isError ? (
+          <div className={s.error}>
+            조회 중 오류가 발생했습니다.
+            <div className={s.errorSub}>{(error as any)?.message ?? ""}</div>
+          </div>
+        ) : data.length === 0 ? (
+          <div className={s.empty}>등록된 과목이 없습니다.</div>
+        ) : (
+          <table className={s.table}>
+            <thead>
+              <tr>
+                <th className={s.th} style={{ width: "34%" }}>과목명</th>
+                <th className={s.th} style={{ width: "12%" }}>학점</th>
+                {isMajor && <th className={s.th} style={{ width: "14%" }}>설계학점</th>}
+                <th className={s.th} style={{ width: isMajor ? "14%" : "28%" }}>성적</th>
+                <th className={s.th} style={{ width: "26%" }}>작업</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.map((c, idx) => (
+                <tr key={c.id ?? `${c.name}-${idx}`} className={idx % 2 ? s.rowEven : undefined}>
+                  <td className={s.td}>{c.name}</td>
+                  <td className={s.td}>{c.credit}</td>
+                  {isMajor && <td className={s.td}>{c.designedCredit ?? "-"}</td>}
+                  <td className={s.td}>{c.grade || "-"}</td>
+                  <td className={s.tdActions}>
+                    <div className={s.btnGroup}>
+                      <button className={s.btnGhost} onClick={() => setEditing(c)}>수정</button>
+                      <button
+                        className={s.btnDanger}
+                        onClick={() => {
+                          if (window.confirm(`"${c.name}" 과목을 삭제할까요?`)) {
+                            deleteMutation.mutate(c.id);
+                          }
+                        }}
+                        disabled={deleteMutation.isPending}
+                        title="삭제"
+                      >
+                        {deleteMutation.isPending ? "삭제 중…" : "삭제"}
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      {/* 수정 모달 (분리 컴포넌트) */}
+      <EditCourseModal
+        open={!!editing}
+        course={editing}
+        sid={sid}
+        onClose={closeEdit}
+        onSaved={handleEdited}
+      />
+    </div>
+  );
+}

--- a/frontend/gradu-web/src/pages/CurriculumPage.tsx
+++ b/frontend/gradu-web/src/pages/CurriculumPage.tsx
@@ -1,14 +1,33 @@
+// src/pages/CurriculumPage.tsx
 import { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query";
 import { axiosInstance, getStudentId } from "../lib/axios";
 import AddCourseModal from "../components/AddCourseModal";
 import s from "./CurriculumTable.module.css";
 
 type CurriculumItem = {
-  category: string;
+  category: string;            // e.g. "MAJOR", "MAJOR_DESIGNED"
   earnedCredits: number;
   status: "PASS" | "FAIL" | string;
+};
+
+type Course = {
+  id: number;
+  name: string;
+  credit: number;
+  category: string; // "MAJOR", ...
+  grade: string | null; // "A+", "P", ...
+  isEnglish?: boolean;
+};
+
+type RowUI = {
+  key: string;
+  name: string;
+  grad: string;
+  earned: number;
+  status: string;
+  designedEarned?: number;     // 전공행에서만 사용
 };
 
 const KOR_LABELS = {
@@ -44,15 +63,27 @@ const GRAD_REQS: Record<(typeof ORDER)[number], string> = {
   ICT_INTRO: "2",
   FREE_ELECTIVE_BASIC: "9",
   FREE_ELECTIVE_MJR: "0",
-  MAJOR: "60(12)",
+  MAJOR: "60(12)", // 60 전공(설계 12)
 };
+
+// GPA(4.5 만점 기준)
+const GPA_POINTS: Record<string, number> = {
+  "A+": 4.5, A: 4.5, "A0": 4.0,
+  "B+": 3.5, "B0": 3.0,
+  "C+": 2.5, "C0": 2.0,
+  "D+": 1.5, "D0": 1.0,
+  "F": 0,
+};
+
+const PF_GRADES = new Set(["P", "PD", "PASS"]);
 
 export default function CurriculumPage() {
   const sid = getStudentId() || "";
   const qc = useQueryClient();
   const nav = useNavigate();
 
-  const { data = [], isLoading, isError } = useQuery<CurriculumItem[]>({
+  // 카테고리별 합/상태
+  const { data: curData = [], isLoading, isError } = useQuery<CurriculumItem[]>({
     queryKey: ["curriculum", sid],
     enabled: !!sid,
     queryFn: async () => {
@@ -62,10 +93,65 @@ export default function CurriculumPage() {
     },
   });
 
-  const rows = useMemo(() => {
+  // 요약 계산을 위해 전체 과목 조회
+  const { data: courseList = [] } = useQuery<Course[]>({
+    queryKey: ["courses-all", sid],
+    enabled: !!sid,
+    queryFn: async () => {
+      const url = `/api/v1/students/${encodeURIComponent(sid)}/courses`;
+      const { data } = await axiosInstance.get<Course[]>(url);
+      return data ?? [];
+    },
+  });
+
+  // 졸업영어시험 / 학부추가졸업요건 토글
+  const { data: toggles = { gradEnglishPassed: false, deptExtraPassed: false } } = useQuery({
+    queryKey: ["grad-toggles", sid],
+    queryFn: async () => {
+      try {
+        const { data } = await axiosInstance.get(`/api/v1/students/${sid}/summary/toggles`);
+        return data ?? { gradEnglishPassed: false, deptExtraPassed: false };
+      } catch {
+        return { gradEnglishPassed: false, deptExtraPassed: false };
+      }
+    },
+  });
+  const [gradEnglishPassed, setGradEnglishPassed] = useState<boolean>(!!toggles.gradEnglishPassed);
+  const [deptExtraPassed, setDeptExtraPassed] = useState<boolean>(!!toggles.deptExtraPassed);
+
+  const saveToggles = useMutation({
+    mutationFn: async (payload: { gradEnglishPassed: boolean; deptExtraPassed: boolean }) => {
+      await axiosInstance.patch(`/api/v1/students/${sid}/summary/toggles`, payload);
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["grad-toggles", sid] }),
+  });
+
+  // ----- 테이블 행 (전공은 설계와 합쳐서 표기 & 상태는 둘 다 PASS여야 PASS) -----
+  const rows: RowUI[] = useMemo(() => {
     const byCat = new Map<string, CurriculumItem>();
-    data.forEach((it) => byCat.set(it.category, it));
+    curData.forEach((it) => byCat.set(it.category, it));
+
     return ORDER.map((k) => {
+      if (k === "MAJOR") {
+        const major = byCat.get("MAJOR");
+        const majorDesigned = byCat.get("MAJOR_DESIGNED"); // DB에 존재
+
+        const earned = major?.earnedCredits ?? 0;
+        const designedEarned = majorDesigned?.earnedCredits ?? 0;
+
+        const status =
+          major?.status === "PASS" && majorDesigned?.status === "PASS" ? "PASS" : "FAIL";
+
+        return {
+          key: k,
+          name: KOR_LABELS[k],
+          grad: GRAD_REQS[k],
+          earned,
+          designedEarned,
+          status,
+        };
+      }
+
       const item = byCat.get(k);
       return {
         key: k,
@@ -75,25 +161,101 @@ export default function CurriculumPage() {
         status: item?.status ?? "",
       };
     });
-  }, [data]);
+  }, [curData]);
+
+  // ===== 요약 계산 =====
+  const {
+    pfCredits,
+    totalCredits,
+    gpa,
+    engMajorCredits,
+    engLiberalCredits,
+    englishPass,
+    pfPass,
+    totalPass,
+    finalPass,
+  } = useMemo(() => {
+    let pf = 0;
+    let tot = 0;
+    let gpaNum = 0;
+    let gpaDen = 0;
+    let eMajor = 0;
+    let eLib = 0;
+
+    for (const c of courseList) {
+      const credit = c.credit ?? 0;
+      const grade = (c.grade || "").toUpperCase().trim();
+
+      // 총 취득학점: P 포함
+      tot += credit;
+
+      // P/F 과목 합
+      if (PF_GRADES.has(grade)) {
+        pf += credit;
+      } else {
+        const p = GPA_POINTS[grade] ?? null;
+        if (p != null) {
+          gpaNum += credit * p;
+          gpaDen += credit;
+        }
+      }
+
+      // 영어강의
+      if (c.isEnglish) {
+        if (c.category === "MAJOR") eMajor += credit;
+        else eLib += credit;
+      }
+    }
+
+    const gpaVal = gpaDen > 0 ? gpaNum / gpaDen : 0;
+
+    // 1) P/F 합격: 총 취득학점의 30% 이상
+    const pfLimit = Math.floor(tot * 0.3);
+    const pfOk = pf >= pfLimit;
+
+    // 2) 총 취득학점: 130학점 이상
+    const totalOk = tot >= 130;
+
+    // 영어강의: (전공≥21 & 교양≥9) 또는 (전공≥24 & 교양≥6)
+    const englishOk = (eMajor >= 21 && eLib >= 9) || (eMajor >= 24 && eLib >= 6);
+
+    // 최종 판정: 카테고리 PASS(전공은 합쳐진 규칙 반영) + 영어 + PF + 총학점 + 토글 2개
+    const allCatPass = rows.every((r) => r.status === "PASS");
+    const final = allCatPass && englishOk && pfOk && totalOk && gradEnglishPassed && deptExtraPassed;
+
+    return {
+      pfCredits: pf,
+      totalCredits: tot,
+      gpa: gpaVal,
+      engMajorCredits: eMajor,
+      engLiberalCredits: eLib,
+      englishPass: englishOk,
+      pfPass: pfOk,
+      totalPass: totalOk,
+      finalPass: final,
+    };
+  }, [courseList, rows, gradEnglishPassed, deptExtraPassed]);
+
+  const statusText = (s: string) => (s === "PASS" ? "합격" : s === "FAIL" ? "불합격" : s || "-");
+  const sPass = s.statusPass, sFail = s.statusFail;
+  const statusClass = (ok: boolean) => (ok ? sPass : sFail);
 
   const [open, setOpen] = useState(false);
-  const handleSaved = () => qc.invalidateQueries({ queryKey: ["curriculum", sid] });
+  const handleSaved = () => {
+    qc.invalidateQueries({ queryKey: ["curriculum", sid] });
+    qc.invalidateQueries({ queryKey: ["courses-all", sid] });
+  };
 
   if (!sid) return <div className="text-center py-14">로그인 정보를 찾을 수 없습니다.</div>;
   if (isLoading) return <div className="text-center py-14">불러오는 중…</div>;
   if (isError) return <div className="text-center py-14">조회 실패</div>;
 
-  const statusText = (s: string) => (s === "PASS" ? "합격" : s === "FAIL" ? "불합격" : s || "-");
-  const statusClass = (s: string) =>
-    s === "PASS" ? sPass : s === "FAIL" ? sFail : sNeutral;
-  const sPass = s.statusPass, sFail = s.statusFail, sNeutral = s.statusNeutral;
+  // 화면 표시용: 지금 기준 P/F 하한(총 취득학점 30%)
+  const pfLimitNote = Math.floor(totalCredits * 0.3);
 
   return (
     <div className="relative">
-      {/* 카드 */}
       <div className={s.card}>
-        {/* 표 */}
         <div className={s.tableWrap}>
           <table className={s.table}>
             <thead>
@@ -109,27 +271,127 @@ export default function CurriculumPage() {
               {rows.map((row, i) => (
                 <tr key={row.key} className={i % 2 ? s.rowEven : undefined}>
                   <td className={s.td}>{row.name}</td>
-                  <td className={`${s.td}`} style={{ whiteSpace: "nowrap" }}>{row.grad}</td>
-                  <td className={s.td}>{row.earned}</td>
-                  <td className={`${s.td} ${statusClass(row.status)}`}>
+                  <td className={s.td} style={{ whiteSpace: "nowrap" }}>{row.grad}</td>
+
+                  {/* 전공은 전공학점(설계학점) */}
+                  <td className={s.td}>
+                    {row.key === "MAJOR"
+                      ? `${row.earned}(${row.designedEarned ?? 0})`
+                      : row.earned}
+                  </td>
+
+                  <td className={`${s.td} ${row.status === "PASS" ? sPass : sFail}`}>
                     {statusText(row.status)}
                   </td>
                   <td className={s.td}>
                     <button
                       onClick={() => nav(`/curriculum/${row.key.toLowerCase()}`)}
                       className={s.viewBtn}
-                      title="해당 구분 과목 상세 보기"
                     >
                       보기
                     </button>
                   </td>
                 </tr>
               ))}
+
+              {/* ----- 요약 섹션 ----- */}
+              <tr className={s.summarySep}><td colSpan={5} /></tr>
+
+              <tr>
+                <td className={s.tdLabel}>P/F과목 총이수학점</td>
+                <td className={s.tdNote}>총 취득학점의 30% 기준: {pfLimitNote < 39 ? 39 : pfLimitNote}학점 이하</td>
+                <td className={s.tdValue}>{pfCredits}</td>
+                <td className={`${s.td} ${statusClass(pfPass)}`}>{pfPass ? "합격" : "불합격"}</td>
+                <td className={s.td} />
+              </tr>
+
+              <tr>
+                <td className={s.tdLabel}>총 취득학점</td>
+                <td className={s.tdNote}>130학점 이상</td>
+                <td className={s.tdValue}>{totalCredits}</td>
+                <td className={`${s.td} ${statusClass(totalPass)}`}>{totalPass ? "합격" : "불합격"}</td>
+                <td className={s.td} />
+              </tr>
+
+              <tr>
+                <td className={s.tdLabel}>평점 평균</td>
+                <td className={s.tdNote}>4.5 만점 환산</td>
+                <td className={s.tdValue}>{gpa.toFixed(2)}</td>
+                <td className={`${s.td} ${gpa >= 2.0 ? sPass : sFail}`}>{gpa >= 2.0 ? "합격" : "불합격"}</td>
+                <td className={s.td} />
+              </tr>
+
+              <tr>
+                <td className={s.tdLabel}>영어강의 과목이수</td>
+                <td className={s.tdNote}>전공:{engMajorCredits} / 교양:{engLiberalCredits}</td>
+                <td className={s.tdValue}></td>
+                <td className={`${s.td} ${statusClass(englishPass)}`}>{englishPass ? "합격" : "불합격"}</td>
+                <td className={s.td} />
+              </tr>
+
+              <tr>
+                <td className={s.tdLabel}>졸업영어시험</td>
+                <td className={s.tdNote}></td>
+                <td className={s.tdValue}>
+                  <label className={s.toggle}>
+                    <input
+                      type="checkbox"
+                      checked={gradEnglishPassed}
+                      onChange={(e) => setGradEnglishPassed(e.target.checked)}
+                    />
+                    <span />
+                  </label>
+                </td>
+                <td className={`${s.td} ${statusClass(gradEnglishPassed)}`}>{gradEnglishPassed ? "합격" : "불합격"}</td>
+                <td className={s.td}>
+                  <button
+                    className={s.saveBtn}
+                    onClick={() => saveToggles.mutate({ gradEnglishPassed, deptExtraPassed })}
+                    disabled={saveToggles.isPending}
+                  >
+                    저장
+                  </button>
+                </td>
+              </tr>
+
+              <tr>
+                <td className={s.tdLabel}>학부추가졸업요건</td>
+                <td className={s.tdNote}></td>
+                <td className={s.tdValue}>
+                  <label className={s.toggle}>
+                    <input
+                      type="checkbox"
+                      checked={deptExtraPassed}
+                      onChange={(e) => setDeptExtraPassed(e.target.checked)}
+                    />
+                    <span />
+                  </label>
+                </td>
+                <td className={`${s.td} ${statusClass(deptExtraPassed)}`}>{deptExtraPassed ? "합격" : "불합격"}</td>
+                <td className={s.td}>
+                  <button
+                    className={s.saveBtn}
+                    onClick={() => saveToggles.mutate({ gradEnglishPassed, deptExtraPassed })}
+                    disabled={saveToggles.isPending}
+                  >
+                    저장
+                  </button>
+                </td>
+              </tr>
+
+              <tr className={s.summaryFinal}>
+                <td className={s.tdLabel}>공학인증 최종 졸업판정</td>
+                <td className={s.tdNote}></td>
+                <td className={s.tdValue}></td>
+                <td className={`${s.td} ${statusClass(finalPass)}`}>
+                  {finalPass ? "졸업가능" : "졸업불가능"}
+                </td>
+                <td className={s.td} />
+              </tr>
             </tbody>
           </table>
         </div>
 
-        {/* 표 아래 오른쪽 + 버튼 */}
         <div className={s.plusArea}>
           <button
             onClick={() => setOpen(true)}

--- a/frontend/gradu-web/src/pages/CurriculumTable.module.css
+++ b/frontend/gradu-web/src/pages/CurriculumTable.module.css
@@ -89,3 +89,31 @@
   border: 0;
   cursor: pointer;
 }
+
+.summarySep td { height: 10px; background: #f3f4f6; border: none; }
+
+.tdLabel { border: 1px solid #e5e7eb; padding: 12px 16px; background:#fafafa; font-weight:600; }
+.tdNote  { border: 1px solid #e5e7eb; padding: 12px 16px; color:#6b7280; }
+.tdValue { border: 1px solid #e5e7eb; padding: 12px 16px; text-align:center; }
+
+.statusPass { color:#16a34a; font-weight:700; }
+.statusFail { color:#dc2626; font-weight:700; }
+.statusNeutral { color:#6b7280; }
+
+.summaryFinal td { border-top:2px solid #e5e7eb; }
+
+.toggle { position:relative; display:inline-block; width:44px; height:24px; }
+.toggle input { opacity:0; width:0; height:0; }
+.toggle span {
+  position:absolute; cursor:pointer; inset:0; background:#e5e7eb; border-radius:999px; transition:.2s;
+}
+.toggle span:before {
+  content:""; position:absolute; height:18px; width:18px; left:3px; top:3px; background:#fff; border-radius:50%; transition:.2s;
+}
+.toggle input:checked + span { background:#2563eb; }
+.toggle input:checked + span:before { transform:translateX(20px); }
+
+.saveBtn {
+  background:#2563eb; color:#fff; border:none; padding:6px 10px;
+  border-radius:8px; cursor:pointer;
+}

--- a/src/main/java/com/example/gradu/domain/course/controller/CourseController.java
+++ b/src/main/java/com/example/gradu/domain/course/controller/CourseController.java
@@ -1,10 +1,15 @@
 package com.example.gradu.domain.course.controller;
 
 import com.example.gradu.domain.course.dto.CourseRequestDto;
+import com.example.gradu.domain.course.dto.CourseResponseDto;
+import com.example.gradu.domain.course.entity.Course;
 import com.example.gradu.domain.course.service.CourseService;
+import com.example.gradu.domain.curriculum.entity.Category;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -17,5 +22,23 @@ public class CourseController {
     public ResponseEntity<Void> addCourse(@PathVariable String studentId, @RequestBody CourseRequestDto request) {
         courseService.addCourse(studentId, request);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/categories/{category}")
+    public ResponseEntity<List<CourseResponseDto>> getCoursesByCategory(@PathVariable String studentId, @PathVariable Category category) {
+        List<Course> list = courseService.getCoursesByCategory(studentId, category);
+        return ResponseEntity.ok(list.stream().map(CourseResponseDto::from).toList());
+    }
+
+    @PatchMapping("/{courseId}")
+    public ResponseEntity<CourseResponseDto> updateCourse(@PathVariable String studentId, @PathVariable Long courseId, @RequestBody CourseRequestDto requestDto) {
+        Course updated = courseService.updateCourse(studentId, courseId, requestDto);
+        return ResponseEntity.ok(CourseResponseDto.from(updated));
+    }
+
+    @DeleteMapping("/{courseId}")
+    public ResponseEntity<Void> deleteCourse(@PathVariable String studentId, @PathVariable Long courseId) {
+        courseService.deleteCourse(studentId, courseId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/example/gradu/domain/course/dto/CourseResponseDto.java
+++ b/src/main/java/com/example/gradu/domain/course/dto/CourseResponseDto.java
@@ -1,0 +1,32 @@
+package com.example.gradu.domain.course.dto;
+
+import com.example.gradu.domain.course.entity.Course;
+import com.example.gradu.domain.curriculum.entity.Category;
+import lombok.Builder;
+import lombok.Value;
+
+import java.time.LocalDateTime;
+
+@Value
+@Builder
+public class CourseResponseDto {
+    Long id;
+    String name;
+    int credit;
+    int designedCredit;
+    Category category;
+    String grade;
+    LocalDateTime createdAt;
+
+    public static CourseResponseDto from(Course c) {
+        return CourseResponseDto.builder()
+                .id(c.getId())
+                .name(c.getName())
+                .credit(c.getCredit())
+                .designedCredit(c.getDesignedCredit())
+                .category(c.getCategory())
+                .grade(c.getGrade())
+                .createdAt(c.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/example/gradu/domain/course/dto/CourseUpdateRequestDto.java
+++ b/src/main/java/com/example/gradu/domain/course/dto/CourseUpdateRequestDto.java
@@ -1,0 +1,14 @@
+package com.example.gradu.domain.course.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter @NoArgsConstructor @AllArgsConstructor @Builder
+public class CourseUpdateRequestDto {
+    private String name;
+    private int credit;
+    private int designedCredit;
+    private String grade;
+}

--- a/src/main/java/com/example/gradu/domain/course/entity/Course.java
+++ b/src/main/java/com/example/gradu/domain/course/entity/Course.java
@@ -4,6 +4,10 @@ import com.example.gradu.domain.curriculum.entity.Category;
 import com.example.gradu.domain.student.entity.Student;
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -11,11 +15,13 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(name = "course")
+@EntityListeners(AuditingEntityListener.class)
 public class Course {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    // 소유자
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "student_id", nullable = false)
     private Student student;
@@ -31,8 +37,41 @@ public class Course {
     private int credit;
 
     @Column
-    private int designedCredit;
+    private Integer designedCredit; // null 가능성이 있으면 Integer가 안전
 
     @Column(length = 5)
     private String grade;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    /** 의도 기반 변경 메서드들 */
+    public void rename(String newName) {
+        if (newName != null && !newName.isBlank()) this.name = newName;
+    }
+
+    /** 학점 변경 시 차액을 반환해 Curriclum 누적에 반영하게 함 */
+    public int changeCredit(Integer newCredit) {
+        if (newCredit == null) return 0;
+        int old = this.credit;
+        this.credit = newCredit;
+        return newCredit - old; // 차액
+    }
+
+    public void changeDesignedCredit(Integer newDesignedCredit) {
+        if (newDesignedCredit != null) this.designedCredit = newDesignedCredit;
+    }
+
+    public void changeGrade(String newGrade) {
+        if (newGrade != null) this.grade = newGrade;
+    }
+
+    /** 카테고리 변경 시, 외부에서 커리큘럼 이동 처리 필요 */
+    public Category changeCategory(Category newCategory) {
+        if (newCategory == null || newCategory == this.category) return this.category;
+        Category old = this.category;
+        this.category = newCategory;
+        return old; // 이전 카테고리 반환
+    }
 }

--- a/src/main/java/com/example/gradu/domain/course/repository/CourseRepository.java
+++ b/src/main/java/com/example/gradu/domain/course/repository/CourseRepository.java
@@ -1,10 +1,17 @@
 package com.example.gradu.domain.course.repository;
 
 import com.example.gradu.domain.course.entity.Course;
+import com.example.gradu.domain.curriculum.entity.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CourseRepository extends JpaRepository<Course, Long> {
     List<Course> findByStudentStudentId(String studentId);
+    // 학생 + 카테고리별 과목
+    List<Course> findByStudent_StudentIdAndCategoryOrderByCreatedAtDesc(
+            String studentId, Category category
+    );
+    Optional<Course> findByIdAndStudent_StudentId(Long id, String studentId);
 }

--- a/src/main/java/com/example/gradu/domain/course/service/CourseService.java
+++ b/src/main/java/com/example/gradu/domain/course/service/CourseService.java
@@ -1,8 +1,10 @@
 package com.example.gradu.domain.course.service;
 
 import com.example.gradu.domain.course.dto.CourseRequestDto;
+import com.example.gradu.domain.course.dto.CourseResponseDto;
 import com.example.gradu.domain.course.entity.Course;
 import com.example.gradu.domain.course.repository.CourseRepository;
+import com.example.gradu.domain.curriculum.entity.Category;
 import com.example.gradu.domain.curriculum.entity.Curriculum;
 import com.example.gradu.domain.curriculum.repository.CurriculumRepository;
 import com.example.gradu.domain.student.entity.Student;
@@ -13,6 +15,9 @@ import com.example.gradu.global.exception.student.StudentException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -39,6 +44,112 @@ public class CourseService {
 
         Curriculum cur = curriculumRepository.findByStudentStudentIdAndCategory(studentId, request.category())
                 .orElseThrow(() -> new CurriculumException(ErrorCode.CURRICULUM_NOT_FOUND));
+        Curriculum designedCur = curriculumRepository.findByStudentStudentIdAndCategory(studentId, Category.MAJOR_DESIGNED)
+                .orElseThrow(() -> new CurriculumException(ErrorCode.CURRICULUM_NOT_FOUND));
         cur.addEarnedCredits(request.credit());
+        designedCur.addEarnedCredits(request.designedCredit());
+    }
+
+    public List<Course> getCoursesByCategory(String studentId, Category category) {
+        return courseRepository.findByStudent_StudentIdAndCategoryOrderByCreatedAtDesc(studentId, category);
+    }
+
+    @Transactional
+    public Course updateCourse(String studentId, Long courseId, CourseRequestDto request) {
+        Course course = courseRepository.findByIdAndStudent_StudentId(courseId, studentId)
+                .orElseThrow(() -> new CurriculumException(ErrorCode.COURSE_NOT_FOUND));
+
+        // --- 기존 값 백업 ---
+        Category oldCat = course.getCategory();
+        int oldCredit = course.getCredit();
+        int oldDesigned = Optional.ofNullable(course.getDesignedCredit()).orElse(0);
+
+        // --- 신규 값 계산(요청값 없으면 기존 유지) ---
+        Category newCat = (request.category() != null) ? request.category() : oldCat;
+
+        // credit이 null 이 아닐 것 같지만(요청 DTO가 primitive면) 방어적으로 처리
+        int newCredit = (request.credit() != 0) ? request.credit() : oldCredit;
+
+        // 설계학점: 전공에서만 의미. 요청이 null이면 기존값 유지.
+        int reqDesigned = Optional.ofNullable(request.designedCredit()).orElse(oldDesigned);
+        int newDesigned = (newCat == Category.MAJOR) ? reqDesigned : 0; // 비전공이면 0으로 간주
+
+        boolean categoryChanged = (newCat != oldCat);
+        int deltaCredit = newCredit - oldCredit;
+        int deltaDesigned = 0;
+
+        // --- 카테고리별 학점 반영 ---
+        if (categoryChanged) {
+            // 1) 이전 카테고리에서 전량 차감
+            Curriculum prevCur = curriculumRepository.findByStudentStudentIdAndCategory(studentId, oldCat)
+                    .orElseThrow(() -> new CurriculumException(ErrorCode.CURRICULUM_NOT_FOUND));
+            prevCur.addEarnedCredits(-oldCredit);
+
+            // 2) 새 카테고리에 전량 가산
+            Curriculum newCur = curriculumRepository.findByStudentStudentIdAndCategory(studentId, newCat)
+                    .orElseThrow(() -> new CurriculumException(ErrorCode.CURRICULUM_NOT_FOUND));
+            newCur.addEarnedCredits(newCredit);
+
+            // 3) 전공 설계 누계 반영
+            Curriculum majorDesignedCur = curriculumRepository.findByStudentStudentIdAndCategory(studentId, Category.MAJOR_DESIGNED)
+                    .orElseThrow(() -> new CurriculumException(ErrorCode.CURRICULUM_NOT_FOUND));
+
+            if (oldCat == Category.MAJOR) {
+                // 전공 → 타 카테고리: 기존 설계학점 전량 차감
+                majorDesignedCur.addEarnedCredits(-oldDesigned);
+            }
+            if (newCat == Category.MAJOR) {
+                // 타 카테고리 → 전공: 새 설계학점 전량 가산
+                majorDesignedCur.addEarnedCredits(newDesigned);
+            }
+        } else {
+            // 카테고리 동일: 학점/설계학점의 차액만 반영
+            if (deltaCredit != 0) {
+                Curriculum cur = curriculumRepository.findByStudentStudentIdAndCategory(studentId, oldCat)
+                        .orElseThrow(() -> new CurriculumException(ErrorCode.CURRICULUM_NOT_FOUND));
+                cur.addEarnedCredits(deltaCredit);
+            }
+
+            if (oldCat == Category.MAJOR) {
+                // 전공일 때만 설계학점 차액 반영
+                deltaDesigned = newDesigned - oldDesigned;
+                if (deltaDesigned != 0) {
+                    Curriculum majorDesignedCur = curriculumRepository.findByStudentStudentIdAndCategory(studentId, Category.MAJOR_DESIGNED)
+                            .orElseThrow(() -> new CurriculumException(ErrorCode.CURRICULUM_NOT_FOUND));
+                    majorDesignedCur.addEarnedCredits(deltaDesigned);
+                }
+            }
+        }
+
+        // --- 엔티티 필드 최종 변경 (변경감지) ---
+        if (request.name() != null) course.rename(request.name());
+        if (request.grade() != null) course.changeGrade(request.grade());
+
+        // 카테고리/학점/설계학점 적용
+        if (categoryChanged) course.changeCategory(newCat);
+        if (deltaCredit != 0) course.changeCredit(newCredit);
+        // 비전공이면 설계학점은 0(또는 null)로 정규화
+        course.changeDesignedCredit((newCat == Category.MAJOR) ? newDesigned : 0);
+
+        return course;
+    }
+
+
+    @Transactional
+    public void deleteCourse(String studentId, Long courseId) {
+        Course course = courseRepository.findByIdAndStudent_StudentId(courseId, studentId)
+                .orElseThrow(() -> new CurriculumException(ErrorCode.COURSE_NOT_FOUND));
+
+        Curriculum cur = curriculumRepository.findByStudentStudentIdAndCategory(studentId, course.getCategory())
+                .orElseThrow(() -> new CurriculumException(ErrorCode.CURRICULUM_NOT_FOUND));
+        cur.addEarnedCredits(-course.getCredit());
+
+        if (course.getCategory() == Category.MAJOR) {
+            Curriculum majorDesignedCur = curriculumRepository.findByStudentStudentIdAndCategory(studentId, Category.MAJOR_DESIGNED)
+                    .orElseThrow(() -> new CurriculumException(ErrorCode.CURRICULUM_NOT_FOUND));
+            majorDesignedCur.addEarnedCredits(-Optional.ofNullable(course.getDesignedCredit()).orElse(0));
+        }
+
+        courseRepository.delete(course);
     }
 }

--- a/src/main/java/com/example/gradu/domain/student/controller/AuthController.java
+++ b/src/main/java/com/example/gradu/domain/student/controller/AuthController.java
@@ -30,7 +30,7 @@ public class AuthController {
 
     @PostMapping("/register")
     public ResponseEntity<Map<String, String>> register(@Valid @RequestBody StudentAuthRequestDto request) {
-        studentService.register(request.getStudentId(), request.getPassword());
+        studentService.register(request.getStudentId(), request.getPassword(), request.getName());
         return ResponseEntity.ok(Map.of("message", "회원가입 성공"));
     }
 

--- a/src/main/java/com/example/gradu/domain/student/dto/StudentAuthRequestDto.java
+++ b/src/main/java/com/example/gradu/domain/student/dto/StudentAuthRequestDto.java
@@ -18,4 +18,6 @@ public class StudentAuthRequestDto {
     @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,}$",
             message = "비밀번호는 8자 이상이며, 최소 하나의 문자, 숫자, 특수문자를 포함해야 합니다")
     private String password;
+
+    private String name;
 }

--- a/src/main/java/com/example/gradu/domain/student/entity/Student.java
+++ b/src/main/java/com/example/gradu/domain/student/entity/Student.java
@@ -23,6 +23,7 @@ public class Student {
     private String studentId;
     private String password;
     private String email;
+    private String name;
 
     @CreatedDate
     @Column(updatable = false)

--- a/src/main/java/com/example/gradu/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/gradu/global/exception/ErrorCode.java
@@ -18,7 +18,8 @@ public enum ErrorCode {
     PASSWORD_MISMATCH("A004", HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
 
 
-    CURRICULUM_NOT_FOUND("C001", HttpStatus.NOT_FOUND, "구분을 찾을 수 없습니다.");
+    CURRICULUM_NOT_FOUND("C001", HttpStatus.NOT_FOUND, "구분을 찾을 수 없습니다."),
+    COURSE_NOT_FOUND("C002", HttpStatus.NOT_FOUND, "과목을 찾을 수 없습니다.");
 
 
 

--- a/src/main/java/com/example/gradu/global/security/SecurityConfig.java
+++ b/src/main/java/com/example/gradu/global/security/SecurityConfig.java
@@ -4,6 +4,7 @@ import com.example.gradu.global.security.jwt.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
@@ -12,6 +13,11 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -20,16 +26,54 @@ public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
+    // Springdoc(OpenAPI v3) & Swagger UI 경로
+    private static final String[] SWAGGER_WHITELIST = {
+            "/v3/api-docs/**",
+            "/swagger-ui/**",
+            "/swagger-ui.html"
+    };
+
+    private static final String[] PUBLIC_WHITELIST = {
+            "/api/v1/auth/**",
+    };
+
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(CsrfConfigurer::disable)
-                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .authorizeHttpRequests(authorize -> authorize
-                                .requestMatchers("/api/v1/auth/**").permitAll()
-                                .anyRequest().authenticated())
+                .cors(Customizer.withDefaults())
+                .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        // 스웨거 & 공개 엔드포인트 허용
+                        .requestMatchers(SWAGGER_WHITELIST).permitAll()
+                        .requestMatchers(PUBLIC_WHITELIST).permitAll()
+                        // 그 외는 인증 필요
+                        .anyRequest().authenticated()
+                )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
         return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+
+        // ★ 정확한 오리진 지정
+        config.setAllowedOrigins(List.of(
+                "http://localhost:5173"       // 개발
+                //, "https://your-frontend-domain.com"  // 운영
+        ));
+
+        config.setAllowedMethods(List.of("GET","POST","PUT","PATCH","DELETE","OPTIONS"));
+        config.setAllowedHeaders(List.of("Authorization","Content-Type","X-Requested-With"));
+        config.setExposedHeaders(List.of("Authorization")); // (필요시) 응답 헤더 노출
+        config.setAllowCredentials(true); // ★ 쿠키를 주고받기 위해 필수
+        config.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
     }
 
     @Bean

--- a/src/main/java/com/example/gradu/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/gradu/global/security/jwt/JwtAuthenticationFilter.java
@@ -22,14 +22,34 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     public static final String TOKEN_PREFIX = "Bearer ";
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String u = request.getRequestURI();
+        return u.startsWith("/api/v1/auth/") ||
+                u.startsWith("/v3/api-docs") ||
+                u.startsWith("/swagger-ui") ||
+                u.startsWith("/actuator");
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain)
+            throws ServletException, IOException {
+
         String bearer = request.getHeader("Authorization");
         if (bearer != null && bearer.startsWith(TOKEN_PREFIX)) {
             String token = bearer.substring(TOKEN_PREFIX.length());
-            if (jwtTokenProvider.isTokenValid(token)) {
-                String studentId = jwtTokenProvider.getStudentIdFromToken(token);
-                UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(studentId, null, Collections.emptyList());
-                SecurityContextHolder.getContext().setAuthentication(auth);
+            try {
+                if (jwtTokenProvider.isTokenValid(token)) {
+                    String studentId = jwtTokenProvider.getStudentIdFromToken(token);
+                    UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(studentId, null, Collections.emptyList());
+                    SecurityContextHolder.getContext().setAuthentication(auth);
+                }
+            } catch (io.jsonwebtoken.ExpiredJwtException ex) {
+                // ★ 만료된 access 토큰: 여기서 막지 말고 조용히 통과
+                //    (/api는 401/403이 날 수 있고, 프론트가 /auth/refresh를 호출함)
+            } catch (io.jsonwebtoken.JwtException | IllegalArgumentException ex) {
+                // 잘못된 토큰: 무시하고 다음 필터로
             }
         }
         filterChain.doFilter(request, response);

--- a/src/main/java/com/example/gradu/global/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/example/gradu/global/security/jwt/JwtTokenProvider.java
@@ -24,9 +24,10 @@ public class JwtTokenProvider {
         this.signingKey = Keys.hmacShaKeyFor(jwtProperties.getSecret().getBytes(UTF_8));
     }
 
-    public String generateAccessToken(String studentId) {
+    public String generateAccessToken(String studentId, String name) {
         String token =  Jwts.builder()
                 .setSubject(studentId)
+                .claim("name", name)
                 .setIssuedAt(new Date())
                 .setExpiration(new Date(System.currentTimeMillis() + jwtProperties.getAccessExpiration()))
                 .signWith(signingKey)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,12 +7,18 @@ spring:
       port: 6379
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate:
         format_sql: true
         dialect: org.hibernate.dialect.MySQLDialect
+
+logging:
+  level:
+    org.springframework.security: DEBUG
+    com.example.gradu: DEBUG
+
 
 app:
   email:


### PR DESCRIPTION
- 개요
    - React 앱과 백엔드 간 통신을 위해 CORS 설정, JWT 인증 필터, 공개 경로 화이트리스트를 구성했습니다. 세션을 STATELESS로 전환하여 토큰 기반 인증 흐름을 명확히 했습니다. 도메인 서비스 레이어(CourseService)는 변경 없이 그대로 사용됩니다.

- 변경 내용
    - CORS
        - 개발 오리진 허용(예: [http://localhost:5173/](http://localhost:5173))
        - credentials 허용, Authorization 헤더 노출
        - 허용 메서드/헤더/프리플라이트 캐시 설정

    - 보안
        - JwtAuthenticationFilter 등록(UsernamePasswordAuthenticationFilter 이전)
        - SessionCreationPolicy.STATELESS 적용

    - 접근 제어
        - /api/v1/auth/** 및 Swagger UI/Docs 경로 permitAll

    - 기타
        - PasswordEncoder(BCrypt) 빈 구성 확인/정리

- 변경 범위(영향도)
    - SecurityConfig 중심 변경
    - 도메인 서비스(CourseService: add/get/update/delete)는 시그니처/로직 변경 없음

- 테스트 방법
    - 백엔드 실행 후, React 앱(dev 서버)에서 다음 확인
        - 인증 없는 공개 API(/api/v1/auth/**) 정상 호출
        - 로그인 후 발급된 토큰으로 보호 API 호출 시 200 응답
        - 토큰 미포함 시 401 응답
        - 브라우저 네트워크 탭에서 CORS 프리플라이트(OPTIONS) 204/200 및 실제 요청 성공 확인
        - 응답 헤더에 Authorization 노출 확인(필요 시)

    - axios 사용 시 withCredentials 설정 및 Authorization 헤더 포함 확인

- 롤백 계획
    - 문제 발생 시 SecurityConfig의 CORS/필터/whitelist 변경을 되돌리고, 세션 정책을 기존값으로 복구

- 체크리스트
    - [ ] 공개 엔드포인트 접근 가능
    - [ ] 인증 필요 엔드포인트는 토큰 없을 때 401
    - [ ] React(dev) 오리진에서 CORS 에러 없음
    - [ ] 토큰 갱신/만료 흐름 점검
    - [ ] 문서/주석 최신화