### PR TITLE
feat(curriculum): 학기별 보기 UX 개선 및 AddCourseModal 학기 연동 추가

### DIFF
--- a/frontend/gradu-web/src/pages/CurriculumPage.tsx
+++ b/frontend/gradu-web/src/pages/CurriculumPage.tsx
@@ -1,19 +1,18 @@
 // src/pages/CurriculumPage.tsx
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query";
 import { axiosInstance, getStudentId } from "../lib/axios";
 import AddCourseModal from "../components/AddCourseModal";
 import s from "./CurriculumTable.module.css";
 
-// 숫자 포맷: 정수면 정수, 아니면 소수1자리
+/* ===================== 공통 유틸 ===================== */
 const fmtCred = (n?: number | null) => {
   if (n == null || Number.isNaN(n)) return "-";
-  const v = Math.round(n * 10) / 10; // 부동소수 오차 보정
+  const v = Math.round(n * 10) / 10;
   return Number.isInteger(v) ? String(v) : v.toFixed(1);
 };
 
-// ---- 컨페티 & 빵빠레 (지연 로드 + WebAudio) ----
 type ConfettiFn = (opts?: any) => void;
 let _confetti: ConfettiFn | null = null;
 async function getConfetti(): Promise<ConfettiFn> {
@@ -22,7 +21,6 @@ async function getConfetti(): Promise<ConfettiFn> {
   _confetti = mod.default;
   return _confetti!;
 }
-
 async function fireConfetti(duration = 1800) {
   const confetti = await getConfetti();
   const end = Date.now() + duration;
@@ -33,7 +31,7 @@ async function fireConfetti(duration = 1800) {
   })();
 }
 
-// 서버 Summary 응답 타입
+/* ===================== 서버 타입 ===================== */
 type SummaryRow = {
   key: string;
   name: string;
@@ -58,22 +56,141 @@ type SummaryDto = {
   finalPass: boolean;
 };
 
+/* ===================== 학기/과목 타입 ===================== */
+export type Term = "1" | "2" | "sum" | "win";
+type CourseLite = {
+  id: number;
+  name: string;
+  category: string;
+  credit: number;
+  grade: string | null;
+  isEnglish: boolean;
+  academicYear: number; // ex) 2025
+  term: Term;           // '1' | 'sum' | '2' | 'win'
+};
+
+const TERM_ORDER: Record<Term, number> = { "1": 0, sum: 1, "2": 2, win: 3 };
+const CATEGORY_LABELS: Record<string, string> = {
+  FAITH_WORLDVIEW: "신앙및세계관",
+  PERSONALITY_LEADERSHIP: "인성및리더십",
+  PRACTICAL_ENGLISH: "실무영어",
+  GENERAL_EDU: "전문교양",
+  BSM: "BSM",
+  ICT_INTRO: "ICT융합기초",
+  FREE_ELECTIVE_BASIC: "자유선택(교양)",
+  FREE_ELECTIVE_MJR: "자유선택(교양또는비교양)",
+  MAJOR: "전공",
+};
+
+function formatSemester(yy: number, term: Term) {
+  const y2 = String(yy).slice(-2);
+  const t = term === "1" || term === "2" ? term : term === "sum" ? "summer" : "winter";
+  return `${y2}-${t}`;
+}
+function nextSemester(y: number, t: Term): { year: number; term: Term } {
+  if (t === "1") return { year: y, term: "sum" };
+  if (t === "sum") return { year: y, term: "2" };
+  if (t === "2") return { year: y, term: "win" };
+  return { year: y + 1, term: "1" }; // win 다음은 다음해 1학기
+}
+
+/* ===================== 뷰 타입 ===================== */
+type View = "summary" | "semester";
+
+/* 임시로 만든(아직 서버에 없는) 새 학기 그룹 구조 */
+type PlannedGroup = { key: string; year: number; term: Term; items: CourseLite[] };
+
 export default function CurriculumPage() {
   const sid = getStudentId() || "";
   const qc = useQueryClient();
   const nav = useNavigate();
 
+  /* ===== 탭 상태 ===== */
+  const [view, setView] = useState<View>("summary");
+
+  /* ===== 요약 데이터 ===== */
   const { data: summary, isLoading, isError } = useQuery<SummaryDto>({
     queryKey: ["summary", sid],
     enabled: !!sid,
     queryFn: async () => {
-      const url = `/api/v1/students/${encodeURIComponent(sid)}/summary`;
-      const { data } = await axiosInstance.get<SummaryDto>(url);
+      const { data } = await axiosInstance.get<SummaryDto>(
+        `/api/v1/students/${encodeURIComponent(sid)}/summary`
+      );
       return data;
     },
     refetchOnWindowFocus: false,
   });
 
+  /* ===== 학기별: 서버 과목 전체 ===== */
+  const {
+    data: allCourses = [],
+    isLoading: isLoadingSem,
+    isError: isErrorSem,
+  } = useQuery<CourseLite[]>({
+    queryKey: ["courses-semester", sid],
+    enabled: !!sid && view === "semester",
+    queryFn: async () => {
+      const cats = Object.keys(CATEGORY_LABELS);
+      const results = await Promise.allSettled(
+        cats.map((cat) =>
+          axiosInstance.get<CourseLite[]>(
+            `/api/v1/students/${encodeURIComponent(sid)}/courses/categories/${encodeURIComponent(
+              cat
+            )}`
+          )
+        )
+      );
+      const merged: CourseLite[] = [];
+      results.forEach((r) => {
+        if (r.status === "fulfilled" && Array.isArray(r.value.data)) {
+          merged.push(
+            ...r.value.data.map((c: any) => ({
+              id: c.id,
+              name: c.name,
+              category: c.category,
+              credit: c.credit,
+              grade: c.grade ?? null,
+              isEnglish: !!c.isEnglish,
+              academicYear: c.academicYear,
+              term: c.term,
+            }))
+          );
+        }
+      });
+      return merged;
+    },
+  });
+
+  /* ===== 서버 과목을 학기 단위로 그룹 ===== */
+  const serverGroups = useMemo(() => {
+    if (!allCourses?.length) return [] as { key: string; year: number; term: Term; items: CourseLite[] }[];
+    const sorted = [...allCourses].sort((a, b) => {
+      if (a.academicYear !== b.academicYear) return a.academicYear - b.academicYear;
+      return TERM_ORDER[a.term] - TERM_ORDER[b.term];
+    });
+    const groups: { key: string; year: number; term: Term; items: CourseLite[] }[] = [];
+    for (const c of sorted) {
+      const key = `${c.academicYear}-${c.term}`;
+      const last = groups[groups.length - 1];
+      if (last && last.key === key) last.items.push(c);
+      else groups.push({ key, year: c.academicYear, term: c.term, items: [c] });
+    }
+    return groups;
+  }, [allCourses]);
+
+  /* ===== 사용자가 방금 만든 임시 학기들 ===== */
+  const [planned, setPlanned] = useState<PlannedGroup[]>([]);
+
+  /* ===== 두 소스(서버/임시)를 합친 뷰용 그룹 ===== */
+  const mergedGroups = useMemo(() => {
+    const all = [...serverGroups, ...planned];
+    return all.sort((a, b) => {
+      if (a.year !== b.year) return a.year - b.year;
+      return TERM_ORDER[a.term] - TERM_ORDER[b.term];
+    });
+  }, [serverGroups, planned]);
+
+  /* ===== 요약 토글 저장 ===== */
   const [gradEnglishPassed, setGradEnglishPassed] = useState(false);
   const [deptExtraPassed, setDeptExtraPassed] = useState(false);
   useEffect(() => {
@@ -92,43 +209,71 @@ export default function CurriculumPage() {
 
   const statusText = (sTxt: string) =>
     sTxt === "PASS" ? "합격" : sTxt === "FAIL" ? "불합격" : sTxt || "-";
-  const sPassCls = s.statusPass,
-    sFailCls = s.statusFail;
-  const statusClass = (ok: boolean) => (ok ? sPassCls : sFailCls);
+  const statusClass = (ok: boolean) => (ok ? s.statusPass : s.statusFail);
 
-  const [open, setOpen] = useState(false);
-  const handleSaved = () => {
+  /* ===== 과목 추가 모달 (초기 학기 프리필) ===== */
+  const [addOpen, setAddOpen] = useState(false);
+  const [prefill, setPrefill] = useState<{ year?: number; term?: Term }>({});
+  function openAddFor(year?: number, term?: Term) {
+    setPrefill({ year, term });
+    setAddOpen(true);
+  }
+  const closeAdd = () => setAddOpen(false);
+
+  const afterAddSaved = () => {
+    // 서버 요약/학기 목록 갱신
     qc.invalidateQueries({ queryKey: ["summary", sid] });
+    qc.invalidateQueries({ queryKey: ["courses-semester", sid] });
+    setAddOpen(false);
   };
 
+  /* ===== 새 학기(빈 표) 추가 ===== */
+  const lastOfMerged = useMemo(() => {
+    if (mergedGroups.length > 0) return mergedGroups[mergedGroups.length - 1];
+    // 아무 것도 없으면 현재년도 1학기부터 시작
+    const nowY = new Date().getFullYear();
+    return { key: `${nowY}-1`, year: nowY, term: "1" as Term, items: [] as CourseLite[] };
+  }, [mergedGroups]);
+
+  function handleCreateNextSemester() {
+    const { year: ny, term: nt } = nextSemester(lastOfMerged.year, lastOfMerged.term);
+    const key = `${ny}-${nt}`;
+    // 이미 존재하는 학기면 중복 추가 방지
+    if (mergedGroups.some((g) => g.key === key)) {
+      // 그래도 모달은 열어준다(바로 과목 추가)
+      openAddFor(ny, nt);
+      return;
+    }
+    setPlanned((prev) => [...prev, { key, year: ny, term: nt, items: [] }]);
+    openAddFor(ny, nt); // 방금 만든 학기로 프리필
+  }
+
+  /* ===== 축하 연출 ===== */
   const hasCelebratedRef = useRef(false);
   const [showBanner, setShowBanner] = useState(false);
-
-  // finalPass가 true로 "전환"될 때 1회 축하
   useEffect(() => {
     if (!summary) return;
     if (summary.finalPass && !hasCelebratedRef.current) {
       hasCelebratedRef.current = true;
-      fireConfetti(1800);                            // 🎉 컨페티만 실행
+      fireConfetti(1800);
       setShowBanner(true);
       const t = setTimeout(() => setShowBanner(false), 3000);
       return () => clearTimeout(t);
     }
-    if (!summary.finalPass) {
-      hasCelebratedRef.current = false;
-    }
+    if (!summary.finalPass) hasCelebratedRef.current = false;
   }, [summary?.finalPass]);
 
+  /* ===== 가드 ===== */
   if (!sid) return <div className="text-center py-14">로그인 정보를 찾을 수 없습니다.</div>;
   if (isLoading) return <div className="text-center py-14">불러오는 중…</div>;
   if (isError || !summary) return <div className="text-center py-14">조회 실패</div>;
 
-  // P/F 기준 설명용 (정책상 최소 39 적용 시)
   const pfLimitNote = Math.max(39, summary.pfLimit);
 
+  /* ===================== 렌더 ===================== */
   return (
     <div className="relative">
-      {/* 축하 배너 */}
+      {/* 🎉 축하 배너 */}
       {showBanner && (
         <div
           role="status"
@@ -150,208 +295,289 @@ export default function CurriculumPage() {
         </div>
       )}
 
-      <div className={s.card}>
+      {/* 📌 포스트잇 탭 */}
+      <div className={s.ribbonWrap}>
+        <button
+          type="button"
+          className={`${s.ribbon} ${s.ribbonLeft} ${view === "summary" ? s.ribbonActive : ""}`}
+          onClick={() => setView("summary")}
+        >
+          종합 보기
+        </button>
+        <button
+          type="button"
+          className={`${s.ribbon} ${s.ribbonLeft2} ${view === "semester" ? s.ribbonActive : ""}`}
+          onClick={() => setView("semester")}
+        >
+          학기별 보기
+        </button>
+      </div>
+
+      {/* 카드 */}
+      <div className={`${s.card} ${view === "summary" ? s.cardOnTop : s.cardDimmed}`}>
         <div className={s.tableWrap}>
-          <table className={s.table}>
-            <thead>
-              <tr>
-                <th className={s.th} style={{ width: "32%" }}>
-                  카테고리
-                </th>
-                <th className={s.th} style={{ width: "20%" }}>
-                  졸업기준(설계)
-                </th>
-                <th className={s.th} style={{ width: "16%" }}>
-                  취득 학점
-                </th>
-                <th className={s.th} style={{ width: "16%" }}>
-                  상태
-                </th>
-                <th className={s.th} style={{ width: "16%" }}>
-                  상세
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {summary.rows.map((row, i) => (
-                <tr key={row.key} className={i % 2 ? s.rowEven : undefined}>
-                  <td className={s.td}>{row.name}</td>
-                  <td className={s.td} style={{ whiteSpace: "nowrap" }}>
-                    {row.grad}
+          {view === "summary" ? (
+            /* ===================== 종합 보기 ===================== */
+            <table className={s.table}>
+              <thead>
+                <tr>
+                  <th className={s.th} style={{ width: "32%" }}>카테고리</th>
+                  <th className={s.th} style={{ width: "20%" }}>졸업기준(설계)</th>
+                  <th className={s.th} style={{ width: "16%" }}>취득 학점</th>
+                  <th className={s.th} style={{ width: "16%" }}>상태</th>
+                  <th className={s.th} style={{ width: "16%" }}>상세</th>
+                </tr>
+              </thead>
+              <tbody>
+                {summary.rows.map((row, i) => (
+                  <tr key={row.key} className={i % 2 ? s.rowEven : undefined}>
+                    <td className={s.td}>{row.name}</td>
+                    <td className={s.td} style={{ whiteSpace: "nowrap" }}>{row.grad}</td>
+                    <td className={s.td}>
+                      {row.key === "MAJOR"
+                        ? `${fmtCred(row.earned)}(${row.designedEarned ?? 0})`
+                        : fmtCred(row.earned)}
+                    </td>
+                    <td className={`${s.td} ${row.status === "PASS" ? s.statusPass : s.statusFail}`}>
+                      {statusText(row.status)}
+                    </td>
+                    <td className={s.td}>
+                      <button
+                        onClick={() => nav(`/curriculum/${row.key.toLowerCase()}`)}
+                        className={s.viewBtn}
+                      >
+                        보기
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+
+                {/* ----- 요약 섹션 ----- */}
+                <tr className={s.summarySep}><td colSpan={5} /></tr>
+
+                <tr>
+                  <td className={s.tdLabel}>P/F과목 총이수학점</td>
+                  <td className={s.tdNote}>총 취득학점의 30% 기준: {fmtCred(pfLimitNote)}학점 이하</td>
+                  <td className={s.tdValue}>{fmtCred(summary.pfCredits)}</td>
+                  <td className={`${s.td} ${summary.pfPass ? s.statusPass : s.statusFail}`}>
+                    {summary.pfPass ? "합격" : "불합격"}
                   </td>
-                  <td className={s.td}>
-                    {row.key === "MAJOR"
-                      ? `${fmtCred(row.earned)}(${row.designedEarned ?? 0})`
-                      : fmtCred(row.earned)}
+                  <td className={s.td} />
+                </tr>
+
+                <tr>
+                  <td className={s.tdLabel}>총 취득학점</td>
+                  <td className={s.tdNote}>130학점 이상</td>
+                  <td className={s.tdValue}>{fmtCred(summary.totalCredits)}</td>
+                  <td className={`${s.td} ${summary.totalPass ? s.statusPass : s.statusFail}`}>
+                    {summary.totalPass ? "합격" : "불합격"}
                   </td>
-                  <td className={`${s.td} ${row.status === "PASS" ? sPassCls : sFailCls}`}>
-                    {statusText(row.status)}
+                  <td className={s.td} />
+                </tr>
+
+                <tr>
+                  <td className={s.tdLabel}>평점 평균</td>
+                  <td className={s.tdNote}>2.0 이상</td>
+                  <td className={s.tdValue}>{(summary.gpa ?? 0).toFixed(2)}</td>
+                  <td className={`${s.td} ${(summary.gpa ?? 0) >= 2.0 ? s.statusPass : s.statusFail}`}>
+                    {(summary.gpa ?? 0) >= 2.0 ? "합격" : "불합격"}
+                  </td>
+                  <td className={s.td} />
+                </tr>
+
+                <tr>
+                  <td className={s.tdLabel}>영어강의 과목이수</td>
+                  <td className={s.tdNote}>
+                    전공:{fmtCred(summary.engMajorCredits)} / 교양:{fmtCred(summary.engLiberalCredits)}
+                  </td>
+                  <td className={s.tdValue}></td>
+                  <td className={`${s.td} ${summary.englishPass ? s.statusPass : s.statusFail}`}>
+                    {summary.englishPass ? "합격" : "불합격"}
+                  </td>
+                  <td className={s.td} />
+                </tr>
+
+                <tr>
+                  <td className={s.tdLabel}>졸업영어시험</td>
+                  <td className={s.tdNote}></td>
+                  <td className={s.tdValue}>
+                    <label className={s.toggle}>
+                      <input
+                        type="checkbox"
+                        checked={gradEnglishPassed}
+                        onChange={(e) => setGradEnglishPassed(e.target.checked)}
+                      />
+                      <span />
+                    </label>
+                  </td>
+                  <td className={`${s.td} ${statusClass(gradEnglishPassed)}`}>
+                    {gradEnglishPassed ? "합격" : "불합격"}
                   </td>
                   <td className={s.td}>
                     <button
-                      onClick={() => nav(`/curriculum/${row.key.toLowerCase()}`)}
-                      className={s.viewBtn}
+                      className={s.saveBtn}
+                      onClick={() => saveToggles.mutate({ gradEnglishPassed, deptExtraPassed })}
+                      disabled={saveToggles.isPending}
                     >
-                      보기
+                      저장
                     </button>
                   </td>
                 </tr>
-              ))}
 
-              {/* ----- 요약 섹션 ----- */}
-              <tr className={s.summarySep}>
-                <td colSpan={5} />
-              </tr>
+                <tr>
+                  <td className={s.tdLabel}>학부추가졸업요건</td>
+                  <td className={s.tdNote}></td>
+                  <td className={s.tdValue}>
+                    <label className={s.toggle}>
+                      <input
+                        type="checkbox"
+                        checked={deptExtraPassed}
+                        onChange={(e) => setDeptExtraPassed(e.target.checked)}
+                      />
+                      <span />
+                    </label>
+                  </td>
+                  <td className={`${s.td} ${statusClass(deptExtraPassed)}`}>
+                    {deptExtraPassed ? "합격" : "불합격"}
+                  </td>
+                  <td className={s.td}>
+                    <button
+                      type="button"
+                      className={s.saveBtn}
+                      onClick={() => saveToggles.mutate({ gradEnglishPassed, deptExtraPassed })}
+                      disabled={saveToggles.isPending}
+                    >
+                      저장
+                    </button>
+                  </td>
+                </tr>
 
-              <tr>
-                <td className={s.tdLabel}>P/F과목 총이수학점</td>
-                <td className={s.tdNote}>
-                  총 취득학점의 30% 기준: {fmtCred(pfLimitNote)}학점 이하
-                </td>
-                <td className={s.tdValue}>{fmtCred(summary.pfCredits)}</td>
-                <td className={`${s.td} ${statusClass(summary.pfPass)}`}>
-                  {summary.pfPass ? "합격" : "불합격"}
-                </td>
-                <td className={s.td} />
-              </tr>
+                <tr className={s.summaryFinal}>
+                  <td className={s.tdLabel}>공학인증 최종 졸업판정</td>
+                  <td className={s.tdNote}></td>
+                  <td className={s.tdValue}></td>
+                  <td className={`${s.td} ${statusClass(summary.finalPass)}`}>
+                    {summary.finalPass ? "졸업가능" : "졸업불가능"}
+                  </td>
+                  <td className={s.td}></td>
+                </tr>
+              </tbody>
+            </table>
+          ) : (
+            /* ===================== 학기별 보기 ===================== */
+            <div className={s.semesterWrap}>
+              {isLoadingSem ? (
+                <div className="text-center py-10">학기별 데이터를 불러오는 중…</div>
+              ) : isErrorSem ? (
+                <div className="text-center py-10">학기별 데이터를 불러오지 못했습니다.</div>
+              ) : mergedGroups.length === 0 ? (
+                <div className="text-center py-10">등록된 과목이 없습니다.</div>
+              ) : (
+                <>
+                  {mergedGroups.map((g) => (
+                    <div className={s.semesterCard} key={g.key}>
+                      <div className={s.semesterHeader}>
+                        {formatSemester(g.year, g.term)}
+                        <button
+                          className={s.semesterAddSmall}
+                          onClick={() => openAddFor(g.year, g.term)}
+                          title="이 학기에 과목 추가"
+                        >
+                          과목 추가
+                        </button>
+                      </div>
 
-              <tr>
-                <td className={s.tdLabel}>총 취득학점</td>
-                <td className={s.tdNote}>130학점 이상</td>
-                <td className={s.tdValue}>{fmtCred(summary.totalCredits)}</td>
-                <td className={`${s.td} ${statusClass(summary.totalPass)}`}>
-                  {summary.totalPass ? "합격" : "불합격"}
-                </td>
-                <td className={s.td} />
-              </tr>
+                      <table className={s.table}>
+                        <thead>
+                          <tr>
+                            <th className={s.th} style={{ width: "40%" }}>과목명</th>
+                            <th className={s.th} style={{ width: "20%" }}>카테고리</th>
+                            <th className={s.th} style={{ width: "12%" }}>학점</th>
+                            <th className={s.th} style={{ width: "14%" }}>성적</th>
+                            <th className={s.th} style={{ width: "14%" }}>작업</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {(g.items.length ? g.items : []).map((c, idx) => (
+                            <tr key={c.id ?? `${c.name}-${idx}`} className={idx % 2 ? s.rowEven : undefined}>
+                              <td className={s.td}>
+                                {c.name} {c.isEnglish ? <span className={s.badgeEng}>ENG</span> : null}
+                              </td>
+                              <td className={s.td}>{CATEGORY_LABELS[c.category] ?? c.category}</td>
+                              <td className={s.td}>{fmtCred(c.credit)}</td>
+                              <td className={s.td}>{c.grade ?? "-"}</td>
+                              <td className={s.td}>
+                                <button
+                                  className={s.viewBtn}
+                                  onClick={() => nav(`/curriculum/${c.category.toLowerCase()}`)}
+                                  title="카테고리 상세로 이동"
+                                >
+                                  보기
+                                </button>
+                              </td>
+                            </tr>
+                          ))}
+                          {/* 임시로 만든 빈 표에도 안내 한 줄 */}
+                          {g.items.length === 0 && (
+                            <tr>
+                              <td className={s.td} colSpan={5} style={{ color: "#6b7280" }}>
+                                이 학기에 아직 과목이 없습니다. &nbsp;
+                                <button className={s.viewBtn} onClick={() => openAddFor(g.year, g.term)}>
+                                  과목 추가
+                                </button>
+                              </td>
+                            </tr>
+                          )}
+                        </tbody>
+                      </table>
+                    </div>
+                  ))}
 
-              <tr>
-                <td className={s.tdLabel}>평점 평균</td>
-                <td className={s.tdNote}>2.0 이상</td>
-                <td className={s.tdValue}>{(summary.gpa ?? 0).toFixed(2)}</td>
-                <td className={`${s.td} ${(summary.gpa ?? 0) >= 2.0 ? sPassCls : sFailCls}`}>
-                  {(summary.gpa ?? 0) >= 2.0 ? "합격" : "불합격"}
-                </td>
-                <td className={s.td} />
-              </tr>
+                  {/* 하단 바 버튼 (파란 점선) */}
+                  {view === "semester" && (
+                    <div className={s.semesterAddBar}>
+                      <button
+                        type="button"
+                        className={s.semesterAddBtn}
+                        onClick={handleCreateNextSemester}
+                        aria-label="새 학기 시간표 만들기"
+                        title="새 학기 시간표 만들기"
+                      >
+                        + 새 학기 시간표 만들기
+                      </button>
+                    </div>
+                  )}
 
-              <tr>
-                <td className={s.tdLabel}>영어강의 과목이수</td>
-                <td className={s.tdNote}>
-                  전공:{fmtCred(summary.engMajorCredits)} / 교양:
-                  {fmtCred(summary.engLiberalCredits)}
-                </td>
-                <td className={s.tdValue}></td>
-                <td className={`${s.td} ${statusClass(summary.englishPass)}`}>
-                  {summary.englishPass ? "합격" : "불합격"}
-                </td>
-                <td className={s.td} />
-              </tr>
-
-              <tr>
-                <td className={s.tdLabel}>졸업영어시험</td>
-                <td className={s.tdNote}></td>
-                <td className={s.tdValue}>
-                  <label className={s.toggle}>
-                    <input
-                      type="checkbox"
-                      checked={gradEnglishPassed}
-                      onChange={(e) => setGradEnglishPassed(e.target.checked)}
-                    />
-                    <span />
-                  </label>
-                </td>
-                <td className={`${s.td} ${statusClass(gradEnglishPassed)}`}>
-                  {gradEnglishPassed ? "합격" : "불합격"}
-                </td>
-                <td className={s.td}>
-                  <button
-                    className={s.saveBtn}
-                    onClick={() => saveToggles.mutate({ gradEnglishPassed, deptExtraPassed })}
-                    disabled={saveToggles.isPending}
-                  >
-                    저장
-                  </button>
-                </td>
-              </tr>
-
-              <tr>
-                <td className={s.tdLabel}>학부추가졸업요건</td>
-                <td className={s.tdNote}></td>
-                <td className={s.tdValue}>
-                  <label className={s.toggle}>
-                    <input
-                      type="checkbox"
-                      checked={deptExtraPassed}
-                      onChange={(e) => setDeptExtraPassed(e.target.checked)}
-                    />
-                    <span />
-                  </label>
-                </td>
-                <td className={`${s.td} ${statusClass(deptExtraPassed)}`}>
-                  {deptExtraPassed ? "합격" : "불합격"}
-                </td>
-                <td className={s.td}>
-                  <button
-                    className={s.saveBtn}
-                    onClick={() => saveToggles.mutate({ gradEnglishPassed, deptExtraPassed })}
-                    disabled={saveToggles.isPending}
-                  >
-                    저장
-                  </button>
-                </td>
-              </tr>
-
-              <tr className={s.summaryFinal}>
-                <td className={s.tdLabel}>공학인증 최종 졸업판정</td>
-                <td className={s.tdNote}>
-                  {/* <label style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
-                    <input
-                      type="checkbox"
-                      checked={soundOn}
-                      onChange={(e) => setSoundOn(e.target.checked)}
-                      aria-label="효과음 켜기"
-                    />
-                    🔊 효과음
-                  </label> */}
-                </td>
-                <td className={s.tdValue}></td>
-                <td className={`${s.td} ${statusClass(summary.finalPass)}`}>
-                  {summary.finalPass ? "졸업가능" : "졸업불가능"}
-                </td>
-                <td className={s.td}>
-                  {/* <button
-                    className={s.viewBtn}
-                    onClick={() => {
-                      fireConfetti(1500);
-                      if (soundOn) playFanfare().catch(() => {});
-                      setShowBanner(true);
-                      setTimeout(() => setShowBanner(false), 3000);
-                    }}
-                    title="축하 연출 다시 보기"
-                    aria-label="축하 연출 다시 보기"
-                  >
-                    축하 다시보기
-                  </button> */}
-                </td>
-              </tr>
-            </tbody>
-          </table>
+                </>
+              )}
+            </div>
+          )}
         </div>
 
-        <div className={s.plusArea}>
-          <button
-            onClick={() => setOpen(true)}
-            aria-label="과목 추가"
-            title="과목 추가"
-            className={s.plusBtn}
-          >
-            +
-          </button>
-        </div>
+        {/* + 버튼은 종합 보기에서만 노출, 카드 우하단 */}
+        {view === "summary" && (
+          <div className={s.plusArea}>
+            <button
+              onClick={() => openAddFor(undefined, undefined)}
+              aria-label="과목 추가"
+              title="과목 추가"
+              className={s.plusBtn}
+            >
+              +
+            </button>
+          </div>
+        )}
       </div>
 
-      <AddCourseModal open={open} sid={sid} onClose={() => setOpen(false)} onSaved={handleSaved} />
+      {/* 과목 추가 모달 (년도/학기 프리필) */}
+      <AddCourseModal
+        open={addOpen}
+        sid={sid}
+        onClose={closeAdd}
+        onSaved={afterAddSaved}
+        initialYear={prefill.year}
+        initialTerm={prefill.term}
+      />
     </div>
   );
 }

--- a/frontend/gradu-web/src/pages/CurriculumTable.module.css
+++ b/frontend/gradu-web/src/pages/CurriculumTable.module.css
@@ -1,119 +1,105 @@
-/* 카드 래퍼 */
 .card {
   max-width: 1000px;
-  margin: 0 auto;
+  margin: 18px auto 0;
   background: #fff;
   border-radius: 16px;
   box-shadow: 0 1px 2px rgba(0,0,0,0.05);
   padding: 24px;
+  position: relative;
+  z-index: 10;
 }
 
-/* 표 외곽(둥근 모서리 + 테두리) */
-.tableWrap {
-  border: 1px solid #d1d5db;
-  border-radius: 12px;
-  overflow: hidden;
-}
-
-/* 표 기본 */
-.table {
-  width: 100%;
-  border-collapse: separate;
-  border-spacing: 0;
-  text-align: center;
-  font-size: 15px;
-}
-
-/* 헤더 셀 */
-.th {
-  background: #f9fafb;
-  color: #374151;
-  border: 1px solid #e5e7eb;
-  padding: 12px 16px;
-}
-
-/* 바디 셀 */
-.td {
-  border: 1px solid #e5e7eb;
-  padding: 12px 16px;
-}
-
-/* 짝수 행 배경 */
-.rowEven {
-  background: rgba(249, 250, 251, 0.4);
-}
-
-/* 상태 컬러 */
-.statusPass {
-  color: #2563eb;
-  font-weight: 600;
-}
-.statusFail {
-  color: #dc2626;
-  font-weight: 600;
-}
-.statusNeutral {
-  color: #374151;
-}
-
-/* 보기 버튼 */
-.viewBtn {
-  padding: 6px 10px;
-  border-radius: 9999px;
-  font-size: 14px;
-  background: #fff;
-  border: 1px solid #d1d5db;
-  cursor: pointer;
-}
-
-/* 표 아래 + 버튼 영역(오른쪽 정렬) */
-.plusArea {
-  margin-top: 16px;
-  display: flex;
-  justify-content: flex-end;
-}
-
-/* + 버튼 */
-.plusBtn {
-  height: 48px;
-  width: 48px;
-  border-radius: 9999px;
-  background: #2563eb;
-  color: #fff;
-  font-size: 24px;
-  line-height: 1;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  box-shadow: 0 4px 10px rgba(37, 99, 235, 0.25);
-  border: 0;
-  cursor: pointer;
-}
-
-.summarySep td { height: 10px; background: #f3f4f6; border: none; }
-
-.tdLabel { border: 1px solid #e5e7eb; padding: 12px 16px; background:#fafafa; font-weight:600; }
-.tdNote  { border: 1px solid #e5e7eb; padding: 12px 16px; color:#6b7280; }
-.tdValue { border: 1px solid #e5e7eb; padding: 12px 16px; text-align:center; }
+.tableWrap { border: 1px solid #d1d5db; border-radius: 12px; overflow: hidden; }
+.table { width: 100%; border-collapse: separate; border-spacing: 0; text-align: center; font-size: 15px; }
+.th { background: #f9fafb; color: #374151; border: 1px solid #e5e7eb; padding: 12px 16px; }
+.td { border: 1px solid #e5e7eb; padding: 12px 16px; }
+.rowEven { background: rgba(249, 250, 251, 0.4); }
 
 .statusPass { color:#16a34a; font-weight:700; }
 .statusFail { color:#dc2626; font-weight:700; }
 .statusNeutral { color:#6b7280; }
 
+.viewBtn { padding: 6px 10px; border-radius: 9999px; font-size: 14px; background: #fff; border: 1px solid #d1d5db; cursor: pointer; }
+
+.plusArea { margin-top: 16px; display: flex; justify-content: flex-end; }
+.plusBtn { height: 48px; width: 48px; border-radius: 9999px; background: #2563eb; color: #fff; font-size: 24px; line-height: 1; display: flex; align-items: center; justify-content: center; box-shadow: 0 4px 10px rgba(37, 99, 235, 0.25); border: 0; cursor: pointer; }
+
+.summarySep td { height: 10px; background: #f3f4f6; border: none; }
+.tdLabel { border: 1px solid #e5e7eb; padding: 12px 16px; background:#fafafa; font-weight:600; }
+.tdNote  { border: 1px solid #e5e7eb; padding: 12px 16px; color:#6b7280; }
+.tdValue { border: 1px solid #e5e7eb; padding: 12px 16px; text-align:center; }
 .summaryFinal td { border-top:2px solid #e5e7eb; }
 
+/* 토글 */
 .toggle { position:relative; display:inline-block; width:44px; height:24px; }
 .toggle input { opacity:0; width:0; height:0; }
-.toggle span {
-  position:absolute; cursor:pointer; inset:0; background:#e5e7eb; border-radius:999px; transition:.2s;
-}
-.toggle span:before {
-  content:""; position:absolute; height:18px; width:18px; left:3px; top:3px; background:#fff; border-radius:50%; transition:.2s;
-}
+.toggle span { position:absolute; inset:0; background:#e5e7eb; border-radius:999px; transition:.2s; }
+.toggle span:before { content:""; position:absolute; height:18px; width:18px; left:3px; top:3px; background:#fff; border-radius:50%; transition:.2s; }
 .toggle input:checked + span { background:#2563eb; }
 .toggle input:checked + span:before { transform:translateX(20px); }
 
-.saveBtn {
-  background:#2563eb; color:#fff; border:none; padding:6px 10px;
-  border-radius:8px; cursor:pointer;
+/* 저장 버튼 */
+.saveBtn{appearance:none;-webkit-appearance:none;display:inline-block;padding:6px 12px;background:#2563eb;color:#fff;border:0;border-radius:8px;font-weight:600;font-size:14px;cursor:pointer;line-height:1;transition:transform .12s,box-shadow .12s,background-color .12s}
+.saveBtn:hover{background:#1d4ed8;box-shadow:0 2px 8px rgba(37,99,235,.25)}
+.saveBtn:active{transform:translateY(1px)}
+.saveBtn:disabled{background:#94a3b8;color:#f8fafc;cursor:not-allowed;box-shadow:none;transform:none}
+
+/* 리본 탭 */
+.ribbonWrap{position:relative;max-width:1000px;margin:0 auto;height:0;z-index:20}
+.ribbon{position:absolute;top:-26px;padding:8px 14px;border-radius:10px;font-weight:700;font-size:13px;border:1px solid rgba(0,0,0,.08);box-shadow:0 8px 18px rgba(0,0,0,.12);background:#fffbe8;transform:rotate(-2deg);cursor:pointer;user-select:none;transition:transform .15s,box-shadow .15s,background-color .15s}
+.ribbon:hover{transform:translateY(-1px) rotate(-2deg);box-shadow:0 10px 22px rgba(0,0,0,.16)}
+.ribbonActive{background:#fff3c4;box-shadow:0 12px 26px rgba(0,0,0,.18)}
+.ribbonLeft{left:22px}
+.ribbonLeft2{left:120px;transform:rotate(2deg)}
+.ribbonLeft2:hover{transform:translateY(-1px) rotate(2deg)}
+
+/* 학기별 보기 */
+.semesterWrap{padding:12px}
+.semesterCard{border:1px solid #e5e7eb;border-radius:12px;overflow:hidden;background:#fff;margin-bottom:16px}
+.semesterHeader{display:flex;align-items:center;justify-content:space-between;background:#f3f4f6;color:#111827;font-weight:700;padding:10px 12px;border-bottom:1px solid #e5e7eb}
+.badgeEng{margin-left:8px;display:inline-block;padding:2px 8px;font-size:12px;border-radius:9999px;background:#e0f2fe;color:#0369a1;font-weight:700}
+.badgePlan{margin-left:8px;font-size:12px;color:#7c3aed;background:#ede9fe;border-radius:9999px;padding:2px 8px;font-weight:700}
+
+.semesterAddSmall{margin-left:auto;background:#fff;border:1px solid #cbd5e1;color:#1f2937;border-radius:8px;padding:4px 10px;font-size:13px;cursor:pointer}
+.semesterAddSmall:hover{background:#f8fafc}
+
+/* 하단 바 버튼 */
+.semesterAddBar{display:flex;justify-content:center;align-items:center;margin:8px 0 4px}
+.semesterAddBtn{width:100%;max-width:960px;border:2px dashed #c7d2fe;background:#eef2ff;color:#3730a3;font-weight:700;border-radius:10px;padding:12px 16px;cursor:pointer;transition:.15s}
+.semesterAddBtn:hover{background:#e0e7ff;transform:translateY(-1px)}
+
+/* 모달 공통 (AddCourseModal과 톤 맞춤용 – 필요 시 사용) */
+.modalBackdrop{position:fixed;inset:0;background:rgba(0,0,0,.35);display:flex;align-items:center;justify-content:center;z-index:60}
+
+/* 하단 바 버튼 - 이전 디자인 */
+.addBarWrap{
+  display:flex;
+  justify-content:center;
+  padding:12px 8px 4px;
+}
+
+/* 하단 바 버튼 – 파란 점선 스타일 */
+.semesterAddBar {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: 8px 0 4px;
+}
+
+.semesterAddBtn {
+  width: 100%;
+  max-width: 960px;
+  border: 2px dashed #c7d2fe;   /* 파란 점선 테두리 */
+  background: #eef2ff;          /* 연한 파란 배경 */
+  color: #3730a3;               /* 진한 파란 글자 */
+  font-weight: 700;
+  border-radius: 10px;
+  padding: 12px 16px;
+  cursor: pointer;
+  transition: .15s;
+}
+
+.semesterAddBtn:hover {
+  background: #e0e7ff;          /* 호버 시 조금 더 진한 파랑 */
+  transform: translateY(-1px);
 }

--- a/src/main/java/com/example/gradu/domain/course/dto/CourseRequestDto.java
+++ b/src/main/java/com/example/gradu/domain/course/dto/CourseRequestDto.java
@@ -14,5 +14,7 @@ public record CourseRequestDto(
     @NotNull(message = "카테고리는 필수입니다.") Category category,
     @PositiveOrZero(message = "설계 학점은 0 이상이어야 합니다.") int designedCredit,
     boolean isEnglish,
-    String grade
+    String grade,
+    Short academicYear,
+    String term
 ) {}

--- a/src/main/java/com/example/gradu/domain/course/dto/CourseResponseDto.java
+++ b/src/main/java/com/example/gradu/domain/course/dto/CourseResponseDto.java
@@ -16,6 +16,9 @@ public class CourseResponseDto {
     private final String grade;
     @JsonProperty("isEnglish")
     private final Boolean isEnglish;
+    Short academicYear;
+    String term;
+    String displaySemester;
 
     public static CourseResponseDto from(Course c) {
         return CourseResponseDto.builder()
@@ -26,6 +29,9 @@ public class CourseResponseDto {
                 .designedCredit(c.getDesignedCredit())
                 .grade(c.getGrade())
                 .isEnglish(c.getIsEnglish())
+                .academicYear(c.getAcademicYear())
+                .term(c.getTerm().getCode())
+                .displaySemester(c.getDisplaySemester())
                 .build();
     }
 }

--- a/src/main/java/com/example/gradu/domain/course/dto/CourseUpdateRequestDto.java
+++ b/src/main/java/com/example/gradu/domain/course/dto/CourseUpdateRequestDto.java
@@ -16,4 +16,6 @@ public class CourseUpdateRequestDto {
     private String grade;
     private Category category;
     private boolean isEnglish;
+    Short academicYear;
+    String term;
 }

--- a/src/main/java/com/example/gradu/domain/course/entity/Course.java
+++ b/src/main/java/com/example/gradu/domain/course/entity/Course.java
@@ -48,6 +48,15 @@ public class Course {
     @Column(name = "is_english", nullable = false)
     private Boolean isEnglish = false;
 
+    /** 예: 2025 (표시는 25로 가공) */
+    @Column(nullable = false)
+    private Short academicYear;
+
+    /** FIRST/SECOND/SUMMER/WINTER 저장 */
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 10)
+    private Term term;
+
     @CreatedDate
     @Column(updatable = false)
     private LocalDateTime createdAt;
@@ -86,4 +95,15 @@ public class Course {
     public Boolean getIsEnglish() {
         return isEnglish != null ? isEnglish : false;
     }
+
+    public String getDisplaySemester() {
+        int yy = academicYear % 100; // 2025 → 25
+        return yy + "-" + term.getCode(); // "25-1" / "25-sum"
+    }
+
+    public void changeSemester(Short year, Term term) {
+        this.academicYear = year;
+        this.term = term;
+    }
 }
+

--- a/src/main/java/com/example/gradu/domain/course/entity/Term.java
+++ b/src/main/java/com/example/gradu/domain/course/entity/Term.java
@@ -1,0 +1,23 @@
+package com.example.gradu.domain.course.entity;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum Term {
+    FIRST("1"),   // 1학기
+    SECOND("2"),  // 2학기
+    SUMMER("sum"),
+    WINTER("win");
+
+    private final String code;
+    Term(String code) { this.code = code; }
+
+    /** "1" / "2" / "sum" / "win" → Term */
+    public static Term fromCode(String code) {
+        for (Term t : values()) if (t.code.equalsIgnoreCase(code)) return t;
+        throw new IllegalArgumentException("Unknown term code: " + code);
+    }
+
+    /** 직렬화/표시용 코드 */
+    @JsonValue
+    public String getCode() { return code; }
+}

--- a/src/main/java/com/example/gradu/domain/course/service/CourseService.java
+++ b/src/main/java/com/example/gradu/domain/course/service/CourseService.java
@@ -3,6 +3,7 @@ package com.example.gradu.domain.course.service;
 import com.example.gradu.domain.course.dto.CourseRequestDto;
 import com.example.gradu.domain.course.dto.CourseUpdateRequestDto;
 import com.example.gradu.domain.course.entity.Course;
+import com.example.gradu.domain.course.entity.Term;
 import com.example.gradu.domain.course.repository.CourseRepository;
 import com.example.gradu.domain.curriculum.entity.Category;
 import com.example.gradu.domain.curriculum.entity.Curriculum;
@@ -50,6 +51,8 @@ public class CourseService {
                 .designedCredit(request.designedCredit()) // Integer (정수)
                 .grade(request.grade())
                 .isEnglish(request.isEnglish())
+                .academicYear(request.academicYear())
+                .term(Term.fromCode(request.term()))
                 .build();
         courseRepository.save(course);
 
@@ -116,6 +119,16 @@ public class CourseService {
         // 커리큘럼에 반영할 학점 변화량(유닛)
         ctx.deltaUnits = toUnits(ctx.newCredit.subtract(ctx.oldCredit));
 
+        ctx.oldYear = course.getAcademicYear();
+        ctx.oldTerm = course.getTerm();
+
+        ctx.newYear = Optional.ofNullable(request.getAcademicYear()).orElse(ctx.oldYear);
+        ctx.newTerm = Optional.ofNullable(request.getTerm())
+                .map(Term::fromCode)
+                .orElse(ctx.oldTerm);
+
+        ctx.semesterChanged = !ctx.newYear.equals(ctx.oldYear) || ctx.newTerm != ctx.oldTerm;
+
         // 전공 설계 변화량(정수)
         if (ctx.oldCat == Category.MAJOR && ctx.newCat == Category.MAJOR) {
             ctx.deltaDesigned = ctx.newDesigned - ctx.oldDesigned;
@@ -162,15 +175,12 @@ public class CourseService {
     private void applyEntityFieldUpdates(Course course, CourseUpdateRequestDto request, UpdateContext ctx) {
         if (request.getName() != null) course.rename(request.getName());
         if (request.getGrade() != null) course.changeGrade(request.getGrade());
-
         if (ctx.categoryChanged) course.changeCategory(ctx.newCat);
-        // credit(BigDecimal) 변경
         if (ctx.deltaUnits != 0) course.changeCredit(ctx.newCredit);
-
-        // 설계학점: 전공만 유지, 그 외 0
         course.changeDesignedCredit((ctx.newCat == Category.MAJOR) ? ctx.newDesigned : 0);
 
-        // 영어강의 여부 변경이 들어왔다면 반영 (옵션)
+        if (ctx.semesterChanged) course.changeSemester(ctx.newYear, ctx.newTerm);
+
         course.changeEnglish(request.isEnglish());
     }
 
@@ -212,5 +222,9 @@ public class CourseService {
         boolean categoryChanged;
         int deltaUnits;     // 학점 변화량(유닛: ×2)
         int deltaDesigned;  // 전공 설계 변화량(정수)
+
+        Short oldYear; Term oldTerm;
+        Short newYear; Term newTerm;
+        boolean semesterChanged;
     }
 }


### PR DESCRIPTION
### 📋 개요

* 커리큘럼 메인 페이지(`CurriculumPage.tsx`)에 **종합 보기 / 학기별 보기** 탭 리본 추가
* 학기별 보기에서 **년도·학기별로 자동 정렬된 카드형 표 구성**
* 하단의 **“+ 새 학기 시간표 만들기” 버튼을 기존 파란 점선 스타일로 복원**
* 과목 추가 시 `AddCourseModal`에 **년도/학기 초기값 자동 연동**
* 종합 보기 표 레이아웃 및 저장 버튼 정상화

---

### 🧩 주요 변경사항

#### 1️⃣ UI / Layout

* 상단에 **리본형 탭 버튼(종합 보기, 학기별 보기)** 추가
  → 현재 탭 강조(`.ribbonActive`), 시각적 종이 포스트잇 스타일 유지
* 학기별 보기 전환 시 기존 종합 표는 숨김 처리
* 각 학기별 섹션 카드(`.semesterCard`)를 **연도·학기 오름차순 정렬**로 출력
* 학기별 표 하단에 **“+ 새 학기 시간표 만들기” 점선 바 버튼** 복원

  ```css
  border: 2px dashed #c7d2fe;
  background: #eef2ff;
  color: #3730a3;
  ```
* 과목이 없는 학기에는 **“과목 추가” 버튼**을 표 안에 직접 표시

#### 2️⃣ 기능 개선

* `AddCourseModal` 호출 시 **해당 학기의 `year`, `term`을 props로 전달**
  → 모달 내부에서 초기 선택값으로 반영됨 (`initialYear`, `initialTerm`)
* 새 학기 추가 시 자동으로 다음 학기(`nextSemester()`) 계산
  → 예: 2025-2 → 2025-winter → 2026-1
* `finalPass` 전환 시 1회성 🎉컨페티 + 상단 축하 배너 유지

#### 3️⃣ 유지보수 / 스타일 정리

* `.addBarWrap` / `.addBarBtn` 제거 → `.semesterAddBar` / `.semesterAddBtn`로 통일
* `.saveBtn` 복원 및 hover/disabled 상태 유지
* CSS 전반: 표와 버튼의 여백·정렬·그림자 일관화

---

### 🧪 테스트

* ✅ 종합 보기: 요약 표 및 저장 버튼 정상 표시
* ✅ 학기별 보기: 학기 순서 정렬, 과목 추가 모달 정상 작동
* ✅ 새 학기 추가: 점선 바 버튼으로 정상 추가 후 모달 프리필 확인
* ✅ 시각 효과: 리본 탭, 컨페티, 저장 버튼 hover 상태 확인

---

### 🔗 관련 파일

* `src/pages/CurriculumPage.tsx`
* `src/components/AddCourseModal.tsx`
* `src/pages/CurriculumTable.module.css`

---

### ✨ 기대 효과

* 학기별 데이터 관리의 **가시성 향상**
* 과목 추가 흐름의 **컨텍스트 일관성 확보**
* UI 톤앤매너를 유지하면서 **가독성·조작성 개선**
